### PR TITLE
Fixed wrong payload attribute type in "AID-EPH"

### DIFF
--- a/pyubx2/ubxtypes_get.py
+++ b/pyubx2/ubxtypes_get.py
@@ -56,7 +56,7 @@ UBX_PAYLOADS_GET = {
     "AID-ALM": {"svid": U4, "week": U4, "optBlock": ("None", {"dwrd": U4})},
     "AID-AOP": {"gnssId": U1, "svId": U1, "reserved1": U2, "data": U64},
     "AID-EPH": {
-        "svid": U1,
+        "svid": U4,
         "how": U4,
         "optBlock": (
             "None",

--- a/pyubx2/ubxtypes_set.py
+++ b/pyubx2/ubxtypes_set.py
@@ -47,7 +47,7 @@ UBX_PAYLOADS_SET = {
     "AID-ALM": {"svid": U4, "week": U4, "optBlock": ("None", {"dwrd": U4})},
     "AID-AOP": {"gnssId": U1, "svId": U1, "reserved1": U2, "data": U64},
     "AID-EPH": {
-        "svid": U1,
+        "svid": U4,
         "how": U4,
         "optBlock": (
             "None",


### PR DESCRIPTION
Hi, 

Here is a quick fix to the AID-EPH message. I was confused when I saw the values that I was getting, and then noticed a small mistake in the attribute type of field "svid". Naturally, this shifted everything to the left.

Cheers,
Ahmed