### PR TITLE
updated parse() method to support trailing data

### DIFF
--- a/pyubx2/ubxmessage.py
+++ b/pyubx2/ubxmessage.py
@@ -466,19 +466,18 @@ class UBXMessage:
         lenp = UBXMessage.bytes2len(lenb)
         if lenp == 0:
             payload = None
-        elif lenp <= (lenm - 8):
-            payload = message[6 : 6 + lenp ]
         else:
-            raise ube.UBXParseError(
-                (f"Invalid message" f" - too short (truncated?)")
-            )
+            if lenp > (lenm - 8):
+                lenp = lenm - 8 # this would be an invalid message
+            payload = message[6 : 6 + lenp ]
         ckm = message[6 + lenp : 6 + lenp + 2 ]
         if validate:
             if hdr != ubt.UBX_HDR:
                 raise ube.UBXParseError(
                     (f"Invalid message header {hdr}" f" - should be {ubt.UBX_HDR}")
                 )
-            if lenm < (lenp + 8):
+            lenp = UBXMessage.bytes2len(lenb)
+            if lenp > (lenm - 8):
                 raise ube.UBXParseError(
                     (
                         f"Invalid message length {lenm}"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -71,7 +71,8 @@ class ExceptionTest(unittest.TestCase):
             UBXMessage.parse(self.bad_hdr, True)
 
     def testParseBadLen(self):  # test for invalid message length in bytes
-        EXPECTED_ERROR = "Invalid payload length (.*) - should be (.*)"
+        #EXPECTED_ERROR = "Invalid payload length (.*) - should be (.*)"
+        EXPECTED_ERROR = "Invalid message - too short \(truncated\?\)"
         with self.assertRaisesRegex(UBXParseError, EXPECTED_ERROR):
             UBXMessage.parse(self.bad_len, True)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -72,7 +72,7 @@ class ExceptionTest(unittest.TestCase):
 
     def testParseBadLen(self):  # test for invalid message length in bytes
         #EXPECTED_ERROR = "Invalid payload length (.*) - should be (.*)"
-        EXPECTED_ERROR = "Invalid message - too short \(truncated\?\)"
+        EXPECTED_ERROR = r"Invalid message length ([0-9]*) - should be ([0-9]*) \(at least\)"
         with self.assertRaisesRegex(UBXParseError, EXPECTED_ERROR):
             UBXMessage.parse(self.bad_len, True)
 


### PR DESCRIPTION
When processing data coming from a uBlox module, it's normal to receive a packet with more bytes than the expected UBX message (trailing nmea, other UBX messages...), and it's more practical to rely on the validity of the UBX length field than on the "correctness" of the size of the packet being processed. That's how I updated the parse() method: doing this I save a lot of complexity, effort and time doing unnecessary "pre-processing".

I am aware that this change is a trade-off, but a very clear one in my own experience: it's easier to have more data than necessary than to have corrupted (or invalid) data (=UBX messages).