### PR TITLE
Fixed payload attribute type in "NAV-TIMEUTC" message:

### DIFF
--- a/pyubx2/ubxtypes_get.py
+++ b/pyubx2/ubxtypes_get.py
@@ -1498,7 +1498,7 @@ UBX_PAYLOADS_GET = {
     },
     "NAV-TIMEUTC": {
         "iTOW": U4,
-        "tAcc": U1,
+        "tAcc": U4,
         "nano": I4,
         "year": U2,
         "month": U1,


### PR DESCRIPTION
- "tAcc" field was of type U1 instead of U4