### PR TITLE
Update ubxmessage.py

### DIFF
--- a/pyubx2/ubxmessage.py
+++ b/pyubx2/ubxmessage.py
@@ -677,6 +677,18 @@ class UBXMessage:
         """
 
         return self._payload
+    
+    @property
+    def mode(self) -> int:
+        """
+        Message mode getter.
+        
+        :return: msgmode as integer
+        :rtype: int
+        
+        """
+        
+        return self._mode
 
     @staticmethod
     def msgclass2bytes(msgClass: int, msgID: int) -> bytes:


### PR DESCRIPTION
Added msgmode getter property to UBXMessage, in order to support a read-only behavior.

# pyubx2 Pull Request Template

## Description

Implemented read-only property getter for UBXMessage._mode (also known as msgmode) to support reading of mode, but no writing.

Fixes # (issue)
Avoid reading private/protected attribute msg._mode

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py`
module or using your IDE's native Python unittest integration facilities.
Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

-

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
