### PR TITLE
Enhanced ubxtypes_core with RTCM-3X message definitions 

### DIFF
--- a/pyubx2/ubxtypes_core.py
+++ b/pyubx2/ubxtypes_core.py
@@ -394,6 +394,36 @@ UBX_MSGIDS = {
     b"\xf1\x40": "UBX-40",  # Set NMEA message output rate
     b"\xf1\x41": "UBX-41",  # aka PUBX-CONFIG Set Protocols and Baudrate
     # ***************************************************************
+    # RTCM messages
+    # ***************************************************************
+    b"\xf5\x01": "RTCM-3X-TYPE1001", # L1-only GPS RTK observables (Input)
+    b"\xf5\x02": "RTCM-3X-TYPE1002", # Extended L1-only GPS RTK observables (Input)
+    b"\xf5\x03": "RTCM-3X-TYPE1003", # L1/L2 GPS RTK observables (Input)
+    b"\xf5\x04": "RTCM-3X-TYPE1004", # Extended L1/L2 GPS RTK observables (Input)
+    b"\xf5\x05": "RTCM-3X-TYPE1005", # Stationary RTK reference station ARP (Input/output)
+    b"\xf5\x06": "RTCM-3X-TYPE1006", # Stationary RTK reference station ARP with antenna height (Input)
+    b"\xf5\x07": "RTCM-3X-TYPE1007", # Antenna descriptor (Input)
+    b"\xf5\x09": "RTCM-3X-TYPE1009", # L1-only GLONASS RTK observables (Input)
+    b"\xf5\x0a": "RTCM-3X-TYPE1010", # Extended L1-Only GLONASS RTK observables (Input)
+    b"\xf5\xa1": "RTCM-3X-TYPE1011", # L1&L2 GLONASS RTK observables (Input)
+    b"\xf5\xa2": "RTCM-3X-TYPE1012", # Extended L1&L2 GLONASS RTK observables (Input)
+    b"\xf5\x21": "RTCM-3X-TYPE1033", # Receiver and antenna descriptors (Input)
+    b"\xf5\x4a": "RTCM-3X-TYPE1074", # GPS MSM4 (Input/output)
+    b"\xf5\x4b": "RTCM-3X-TYPE1075", # GPS MSM5 (Input)
+    b"\xf5\x4d": "RTCM-3X-TYPE1077", # GPS MSM7 (Input/output)
+    b"\xf5\x54": "RTCM-3X-TYPE1084", # GLONASS MSM4 (Input/output)
+    b"\xf5\x55": "RTCM-3X-TYPE1085", # GLONASS MSM5 (Input)
+    b"\xf5\x57": "RTCM-3X-TYPE1087", # GLONASS MSM7 (Input/output)
+    b"\xf5\x5e": "RTCM-3X-TYPE1094", # Galileo MSM4 (Input/output)
+    b"\xf5\x5f": "RTCM-3X-TYPE1095", # Galileo MSM5 (Input)
+    b"\xf5\x61": "RTCM-3X-TYPE1097", # Galileo MSM7 (Input/output)
+    b"\xf5\x7c": "RTCM-3X-TYPE1124", # BeiDou MSM4 (Input/output)
+    b"\xf5\x7d": "RTCM-3X-TYPE1125", # BeiDou MSM5 (Input)
+    b"\xf5\x7f": "RTCM-3X-TYPE1127", # BeiDou MSM7 (Input/output)
+    b"\xf5\xe6": "RTCM-3X-TYPE1230", # GLONASS L1 and L2 code-phase biases (Input/output)
+    b"\xf5\xfe": "RTCM-3X-TYPE4072_0", # Reference station PVT (u-blox proprietary) (Input/output)
+    b"\xf5\xfd": "RTCM-3X-TYPE4072_1", # Additional reference station information (u-blox proprietary) (Output)
+    # ***************************************************************
     # Dummy message for testing only
     # ***************************************************************
     b"\x66\x66": "FOO-BAR",

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -59,6 +59,21 @@ class ParseTest(unittest.TestCase):
         self.mga_ini1 = b"\xb5b\x13\x40\x14\x00\x01\x00\x01\x02\x01\x02\x03\x04\x01\x02\x03\x04\x01\x02\x03\x04\x01\x02\x03\x04\x93\xc8"
         self.mon_span = b"\xb5b\n1\x14\x01\x00\x01\x00\x00-+-,+-.,-.+,+.-..-,..//./00203017?9398:L]<@C;H<>=A@BDCGJNQRVY[_cgpqyz\x7f\x84\x8c\x90\x99\xa0\xa7\xae\xb0\xae\xaa\xa7\xa2\x9b\x97\x96\x94\x91\x90\x8e\x8c\x8c\x8c\x8b\x8b\x89\x88\x89\x89\x89\x8b\x88\x89\x8a\x89\x8a\x8a\x89\x8a\x8b\x8a\x8a\x8b\x8b\x8c\x8a\x8a\x8a\x8b\x88\x88\x87\x87\x86\x85\x85\x85\x84\x89\x84\x85\x83\x84\x84\x84\x85\x88\x87\x87\x88\x8a\x8a\x8a\x8a\x8b\x8e\x8c\x8d\x8d\x8f\x8e\x8d\x8f\x8e\x8f\x8f\x8e\x8f\x8f\x90\x91\x92\x93\x93\x93\x95\x94\x94\x94\x94\x95\x94\x95\x93\x93\x91\x92\x93\x92\x94\x95\x94\x95\x97\x97\x98\x97\x94\x90\x8d\x86\x82\x7fyupmg`]VRLEB?=;99665422202101///-//.-0-.-/..--,.-+-,--+.,,--,,-*\x00 \xa1\x07 \xa1\x07\x00@\xc4`^\x0c\x00\x00\x00\x15j"
 
+        self.RTCM = {
+                "1006": (b"\xb5b\x022\x08\x00\x02\x04\x00\x00j\x00\xee\x03\x9dA",
+                    "<UBX(RXM-RTCM, version=2, flags=b'\\x04', subType=0, refStation=106, msgType=1006)>"),
+                "1075": (b"\xb5b\x022\x08\x00\x02\x04\x00\x00j\x003\x04\xe3\xcc", 
+                    "<UBX(RXM-RTCM, version=2, flags=b'\\x04', subType=0, refStation=106, msgType=1075)>"),
+                "1085": (b"\xb5b\x022\x08\x00\x02\x04\x00\x00j\x00=\x04\xed\xe0", 
+                    "<UBX(RXM-RTCM, version=2, flags=b'\\x04', subType=0, refStation=106, msgType=1085)>"),
+                "1095": (b"\xb5b\x022\x08\x00\x02\x04\x00\x00j\x00G\x04\xf7\xf4", 
+                    "<UBX(RXM-RTCM, version=2, flags=b'\\x04', subType=0, refStation=106, msgType=1095)>"),
+                "1115": (b"\xb5b\x022\x08\x00\x02\x04\x00\x00j\x00[\x04\x0b\x1c", 
+                    "<UBX(RXM-RTCM, version=2, flags=b'\\x04', subType=0, refStation=106, msgType=1115)>"),
+                "1125": (b"\xb5b\x022\x08\x00\x02\x04\x00\x00j\x00e\x04\x150", 
+                    "<UBX(RXM-RTCM, version=2, flags=b'\\x04', subType=0, refStation=106, msgType=1125)>")
+        }
+
     def tearDown(self):
         pass
 
@@ -333,6 +348,10 @@ class ParseTest(unittest.TestCase):
             "<UBX(MGA-INI-POS_LLH, type=1, version=0, reserved1=513, lat=67305985, lon=67305985, alt=67305985, posAcc=67305985)>",
         )
 
+    def testRTCM(self): # test parser of RTCM-3X messages
+        for item in self.RTCM.values():
+            res = UBXReader.parse(item[0])
+            self.assertEqual(str(res), item[1])
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

Added RTCM-3X message definitions to ubxtypes_core.py, based on ublox F9P manual
Enhanced test cases with RTCM-3X messages 

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py`
module or using your IDE's native Python unittest integration facilities.
Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.



## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x) I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. (didn't find a proper place...)
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
