### PR TITLE
ubxtypes_set.py: dropped LOG-FINDTIME reserved0

### DIFF
--- a/pyubx2/ubxtypes_set.py
+++ b/pyubx2/ubxtypes_set.py
@@ -1057,7 +1057,6 @@ UBX_PAYLOADS_SET = {
     "LOG-FINDTIME": {
         "version": U1,
         "type": U1,
-        "reserved0": U2,
         "year": U2,
         "month": U1,
         "day": U1,


### PR DESCRIPTION
## Description

EDITED: ubxtypes_set.py: dropped LOG-FINDTIME reserved0
- reserved0 corresponds to an error in the UBX doc. The actual frame should be 10 bytes long not 12
- confirmed on ZOE-M8B capturing the Ublox UCenter byte stream for the LOG-FINDTIME command
- acknowleged by Steliau Technology on behalf of Ublox
- gpsd/ubxtool equivalent issue on gitLab: https://gitlab.com/gpsd/gpsd/-/issues/68
- gspd/ubxtool equivalent fix on gitLab: https://gitlab.com/gpsd/gpsd/-/commit/b0e89557be1e9a5cf95d4e189e960b9de2794a1c

Fixes #32

## Testing

ran testsuite.py

Testing Local Version: 1.1.2
found 18 tests in test_static
found 39 tests in test_parse
found 26 tests in test_constructor
found 5 tests in test_bitfields
found 2 tests in test_assistnow
found 30 tests in test_exceptions
found 24 tests in test_specialcases
found 1 tests in test_configdb
found 15 tests in test_stream
----------------------------------------------------------------------
................................................................................................................................................................
----------------------------------------------------------------------
Ran 160 tests in 0.074s

OK

## Checklist:

- [ x ] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] I have made corresponding changes to the documentation.
- [ x ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [ x ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [ x ] My changes generate no new warnings.
- [ x ] Any dependent changes have been merged and published in downstream modules.
- [ x ] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
