### PR TITLE
Parse/set flags for CFG-PRT

### DIFF
--- a/pyubx2/ubxtypes_get.py
+++ b/pyubx2/ubxtypes_get.py
@@ -727,7 +727,13 @@ UBX_PAYLOADS_GET = {
                 "outRTCM3": U1,
             },
         ),
-        "reserved4": U2,
+        "flags": (
+            X2,
+            {
+                "reserved10": U1,
+                "extendedTxTimeout": U1,
+            },
+        ),
         "reserved5": U2,
     },
     "CFG-PWR": {"version": U1, "reserved1": U3, "state": U4},

--- a/pyubx2/ubxtypes_set.py
+++ b/pyubx2/ubxtypes_set.py
@@ -721,7 +721,13 @@ UBX_PAYLOADS_SET = {
                 "outRTCM3": U1,
             },
         ),
-        "reserved4": U2,
+        "flags": (
+            X2,
+            {
+                "reserved10": U1,
+                "extendedTxTimeout": U1,
+            },
+        ),
         "reserved5": U2,
     },
     "CFG-PWR": {"version": U1, "reserved1": U3, "state": U4},


### PR DESCRIPTION
Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

# pyubx2 Pull Request Template

## Description

How to solve different options for different cases? 

for '32.10.25.2 Port configuration for UART ports',
'32.10.25.4 Port configuration for SPI port'
'32.10.25.5 Port configuration for I2C (DDC) port'
![image](https://user-images.githubusercontent.com/13130700/139830018-1d2592ed-924d-4298-984b-7fafd9a4f28b.png)
![image](https://user-images.githubusercontent.com/13130700/139830325-c4091b07-496a-4efa-8817-f980da168c42.png)

'32.10.25.3 Port configuration for USB port'
![image](https://user-images.githubusercontent.com/13130700/139830148-aaf81379-bbd3-4650-b207-bca80acba07a.png)


Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py`
module or using your IDE's native Python unittest integration facilities.
Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [X] Test A
- [x] Test B

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
