### PR TITLE
improve KeyError message Fixes #73

### DIFF
--- a/pyubx2/ubxmessage.py
+++ b/pyubx2/ubxmessage.py
@@ -495,35 +495,50 @@ class UBXMessage:
 
         """
 
-        if self._mode == ubt.POLL:
-            pdict = ubp.UBX_PAYLOADS_POLL[self.identity]
-        elif self._mode == ubt.SET:
-            if self._ubxClass == b"\x13" and self._ubxID != b"\x80":  # MGA SET
-                pdict = self._get_mga_version(ubt.SET, **kwargs)
-            elif self._ubxClass == b"\x02" and self._ubxID == b"\x41":  # RXM-PMREQ SET
-                pdict = self._get_rxmpmreq_version(**kwargs)
-            elif self._ubxClass == b"\x0d" and self._ubxID == b"\x15":  # TIM-VCOCAL SET
-                pdict = self._get_timvcocal_version(**kwargs)
-            elif self._ubxClass == b"\x06" and self._ubxID == b"\x06":  # CFG-DAT SET
-                pdict = self._get_cfgdat_version(**kwargs)
-            else:
-                pdict = ubs.UBX_PAYLOADS_SET[self.identity]
-        else:  # GET message
-            if self._ubxClass == b"\x13" and self._ubxID != b"\x80":  # MGA GET
-                pdict = self._get_mga_version(ubt.GET, **kwargs)
-            elif self._ubxClass == b"\x02" and self._ubxID == b"\x72":  # RXM-PMP
-                pdict = self._get_rxmpmp_version(**kwargs)
-            elif self._ubxClass == b"\x02" and self._ubxID == b"\x59":  # RXM-RLM
-                pdict = self._get_rxmrlm_version(**kwargs)
-            elif self._ubxClass == b"\x06" and self._ubxID == b"\x17":  # CFG-NMEA
-                pdict = self._get_cfgnmea_version(**kwargs)
-            elif self._ubxClass == b"\x01" and self._ubxID == b"\x60":  # NAV-AOPSTATUS
-                pdict = self._get_aopstatus_version(**kwargs)
-            elif self._ubxClass == b"\x01" and self._ubxID == b"\x3C":  # NAV-RELPOSNED
-                pdict = self._get_relposned_version(**kwargs)
-            else:
-                pdict = ubg.UBX_PAYLOADS_GET[self.identity]
-        return pdict
+        try:
+            if self._mode == ubt.POLL:
+                pdict = ubp.UBX_PAYLOADS_POLL[self.identity]
+            elif self._mode == ubt.SET:
+                if self._ubxClass == b"\x13" and self._ubxID != b"\x80":  # MGA SET
+                    pdict = self._get_mga_version(ubt.SET, **kwargs)
+                elif (
+                    self._ubxClass == b"\x02" and self._ubxID == b"\x41"
+                ):  # RXM-PMREQ SET
+                    pdict = self._get_rxmpmreq_version(**kwargs)
+                elif (
+                    self._ubxClass == b"\x0d" and self._ubxID == b"\x15"
+                ):  # TIM-VCOCAL SET
+                    pdict = self._get_timvcocal_version(**kwargs)
+                elif (
+                    self._ubxClass == b"\x06" and self._ubxID == b"\x06"
+                ):  # CFG-DAT SET
+                    pdict = self._get_cfgdat_version(**kwargs)
+                else:
+                    pdict = ubs.UBX_PAYLOADS_SET[self.identity]
+            else:  # GET message
+                if self._ubxClass == b"\x13" and self._ubxID != b"\x80":  # MGA GET
+                    pdict = self._get_mga_version(ubt.GET, **kwargs)
+                elif self._ubxClass == b"\x02" and self._ubxID == b"\x72":  # RXM-PMP
+                    pdict = self._get_rxmpmp_version(**kwargs)
+                elif self._ubxClass == b"\x02" and self._ubxID == b"\x59":  # RXM-RLM
+                    pdict = self._get_rxmrlm_version(**kwargs)
+                elif self._ubxClass == b"\x06" and self._ubxID == b"\x17":  # CFG-NMEA
+                    pdict = self._get_cfgnmea_version(**kwargs)
+                elif (
+                    self._ubxClass == b"\x01" and self._ubxID == b"\x60"
+                ):  # NAV-AOPSTATUS
+                    pdict = self._get_aopstatus_version(**kwargs)
+                elif (
+                    self._ubxClass == b"\x01" and self._ubxID == b"\x3C"
+                ):  # NAV-RELPOSNED
+                    pdict = self._get_relposned_version(**kwargs)
+                else:
+                    pdict = ubg.UBX_PAYLOADS_GET[self.identity]
+            return pdict
+        except KeyError as err:
+            raise KeyError(
+                f"{err} - Check 'msgmode' keyword argument is appropriate for message category"
+            )
 
     def _get_mga_version(self, mode: int, **kwargs) -> dict:
         """

--- a/pyubx2/ubxreader.py
+++ b/pyubx2/ubxreader.py
@@ -387,5 +387,6 @@ class UBXReader:
         except KeyError as err:
             modestr = ["GET", "SET", "POLL"][msgmode]
             raise ube.UBXParseError(
-                (f"Unknown message type clsid {clsid}, msgid {msgid}, mode {modestr}")
+                f"Unknown message type clsid {clsid}, msgid {msgid}, mode {modestr}\n"
+                + "Check 'msgmode' keyword argument is appropriate for message category"
             ) from err

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -336,6 +336,20 @@ class ExceptionTest(unittest.TestCase):
         with self.assertRaisesRegex(UBXTypeError, EXPECTED_ERROR):
             bytes2val(b"\x01", "Z001")
 
+    def testWRONGMSGMODE(self):  # test parse of SET message with GET msgmode
+        EXPECTED_ERROR = (
+            "Unknown message type clsid (.*), msgid (.*), mode GET\n"
+            + "Check 'msgmode' keyword argument is appropriate for message category"
+        )
+        res = UBXMessage(
+            "CFG",
+            "CFG-VALSET",
+            SET,
+            payload=b"\x00\x03\x00\x00\x01\x00\x52\x40\x80\x25\x00\x00",
+        )
+        with self.assertRaisesRegex(UBXParseError, EXPECTED_ERROR):
+            msg = UBXReader.parse(res.serialize())
+
 
 #     # can only be tested by temporarily removing a valid message definition
 #     def testIdentity(self):  # test for invalid message identity

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -341,6 +341,7 @@ class ExceptionTest(unittest.TestCase):
             "Unknown message type clsid (.*), msgid (.*), mode GET\n"
             + "Check 'msgmode' keyword argument is appropriate for message category"
         )
+        EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>"
         res = UBXMessage(
             "CFG",
             "CFG-VALSET",
@@ -349,6 +350,8 @@ class ExceptionTest(unittest.TestCase):
         )
         with self.assertRaisesRegex(UBXParseError, EXPECTED_ERROR):
             msg = UBXReader.parse(res.serialize())
+        msg = UBXReader.parse(res.serialize(), msgmode=SET)
+        self.assertEquals(str(msg), EXPECTED_RESULT)
 
 
 #     # can only be tested by temporarily removing a valid message definition

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -351,7 +351,7 @@ class ExceptionTest(unittest.TestCase):
         with self.assertRaisesRegex(UBXParseError, EXPECTED_ERROR):
             msg = UBXReader.parse(res.serialize())
         msg = UBXReader.parse(res.serialize(), msgmode=SET)
-        self.assertEquals(str(msg), EXPECTED_RESULT)
+        self.assertEqual(str(msg), EXPECTED_RESULT)
 
 
 #     # can only be tested by temporarily removing a valid message definition


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

Clarify error message generated when user attempts to parse a SET message using a msgmode of GET - message text
now reads...

```
Unknown message type clsid (.*), msgid (.*), mode GET
Check 'msgmode' keyword argument is appropriate for message category
```

Fixes #73

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] new test added to test_exceptions.py


## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
