### PR TITLE
modify ESF-MEAS SET treatment - Fixes #76

### DIFF
--- a/pyubx2/ubxmessage.py
+++ b/pyubx2/ubxmessage.py
@@ -151,7 +151,7 @@ class UBXMessage:
             att, tuple
         ):  # repeating group of attributes or subdefined bitfield
             numr, _ = att
-            if numr in (ubt.X1, ubt.X2, ubt.X4, ubt.X6, ubt.X8):  # bitfield
+            if numr in (ubt.X1, ubt.X2, ubt.X4, ubt.X6, ubt.X8, ubt.X24):  # bitfield
                 if self._parsebf:  # if we're parsing bitfields
                     (offset, index) = self._set_attribute_bitfield(
                         att, offset, index, **kwargs
@@ -202,6 +202,14 @@ class UBXMessage:
                 rng = self._calc_num_repeats(attd, self._payload, offset, 0)
             else:  # number of repeats is defined in named attribute
                 rng = getattr(self, numr)
+                # special handling for ESF-MEAS message types
+                if (
+                    self._ubxClass == b"\x10"
+                    and self._ubxID == b"\x02"
+                    and self._mode == ubt.SET
+                ):
+                    if getattr(self, "calibTtagValid", 0):
+                        rng += 1
             # recursively process each group attribute,
             # incrementing the payload offset and index as we go
             for i in range(rng):

--- a/pyubx2/ubxtypes_set.py
+++ b/pyubx2/ubxtypes_set.py
@@ -339,7 +339,7 @@ UBX_PAYLOADS_SET = {
         ),
         "id": U2,
         "group": (
-            "None",
+            "numMeas",
             {  # repeating group * numMeas
                 "data": (
                     X4,

--- a/tests/test_specialcases.py
+++ b/tests/test_specialcases.py
@@ -320,6 +320,42 @@ class SpecialTest(unittest.TestCase):
             "<UBX(CFG-VALGET, version=0, layer=2, position=0, keys_01=1079115777, keys_02=1079181313)>",
         )
 
+    def testESFMEASSET0(self):  # test generation fo ESF-MEAS with calibTtagValid=0
+        EXPECTED_RESULT = "<UBX(ESF-MEAS, timeTag=12345000, timeMarkSent=0, timeMarkEdge=0, calibTtagValid=0, numMeas=1, id=0, dataField_01=188, dataType_01=11)>"
+        msg = UBXMessage(
+            "ESF",
+            "ESF-MEAS",
+            SET,
+            timeTag=12345000,
+            timeMarkSent=0,
+            timeMarkEdge=0,
+            calibTtagValid=0,
+            numMeas=1,
+            dataField_01=188,
+            dataType_01=11,
+        )
+        self.assertEqual(str(msg), EXPECTED_RESULT)
+
+    def testESFMEASSET1(self):  # test generation fo ESF-MEAS with calibTtagValid=1
+        EXPECTED_RESULT = "<UBX(ESF-MEAS, timeTag=12345000, timeMarkSent=0, timeMarkEdge=0, calibTtagValid=1, numMeas=2, id=0, dataField_01=223, dataType_01=9, dataField_02=118, dataType_02=11, dataField_03=12345000, dataType_03=0)>"
+        msg = UBXMessage(
+            "ESF",
+            "ESF-MEAS",
+            SET,
+            timeTag=12345000,
+            timeMarkSent=0,
+            timeMarkEdge=0,
+            calibTtagValid=1,
+            numMeas=2,
+            dataField_01=223,
+            dataType_01=9,
+            dataField_02=118,
+            dataType_02=11,
+            dataField_03=12345000,
+            dataType_03=0,
+        )
+        self.assertEqual(str(msg), EXPECTED_RESULT)
+
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

Modify handling of ESF-MEAS SET messages to use correct data group dimension based on values of `calibTtagValid` and `numMeas`. If `calibTtagValid` is True, `numMeas` is incremented by 1 to cater for the additional appended calibration `dataField` (`dataType` = 0).

Fixes #76

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] Two new tests added to test_specialcases.py

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
