### PR TITLE
Enhance CFG-TP5 POLL handling

### DIFF
--- a/pyubx2/ubxmessage.py
+++ b/pyubx2/ubxmessage.py
@@ -505,7 +505,11 @@ class UBXMessage:
 
         try:
             if self._mode == ubt.POLL:
-                pdict = ubp.UBX_PAYLOADS_POLL[self.identity]
+                # CFG-TP5 POLL
+                if self._ubxClass == b"\x06" and self._ubxID == b"\x31":
+                    pdict = self._get_cfgtp5_version(**kwargs)
+                else:
+                    pdict = ubp.UBX_PAYLOADS_POLL[self.identity]
             elif self._mode == ubt.SET:
                 # MGA SET
                 if self._ubxClass == b"\x13" and self._ubxID != b"\x80":
@@ -550,6 +554,28 @@ class UBXMessage:
             raise KeyError(
                 f"{err} - Check 'msgmode' keyword argument is appropriate for message category"
             )
+
+    def _get_cfgtp5_version(self, **kwargs) -> dict:
+        """
+        Select appropriate CFG-TP5 POLL payload definition by checking
+        length of payload.
+
+        :param kwargs: optional payload key/value pairs
+        :return: dictionary representing payload definition
+        :rtype: dict
+        :raises: UBXMessageError
+
+        """
+
+        if "payload" in kwargs:
+            lp = len(kwargs["payload"])
+        else:
+            lp = 0
+        if lp == 1:
+            pdict = ubp.UBX_PAYLOADS_POLL["CFG-TP5-TPX"]
+        else:
+            pdict = ubp.UBX_PAYLOADS_POLL["CFG-TP5"]
+        return pdict
 
     def _get_mga_version(self, mode: int, **kwargs) -> dict:
         """

--- a/pyubx2/ubxmessage.py
+++ b/pyubx2/ubxmessage.py
@@ -563,7 +563,6 @@ class UBXMessage:
         :param kwargs: optional payload key/value pairs
         :return: dictionary representing payload definition
         :rtype: dict
-        :raises: UBXMessageError
 
         """
 

--- a/pyubx2/ubxtypes_poll.py
+++ b/pyubx2/ubxtypes_poll.py
@@ -90,8 +90,8 @@ UBX_PAYLOADS_POLL = {
     "CFG-TMODE2": {},
     "CFG-TMODE3": {},
     "CFG-TP": {},
-    "CFG-TP5": {},
-    "CFG-TP5-TPX": {"tIdx": U1},
+    "CFG-TP5": {},  # used if no payload keyword specified
+    "CFG-TP5-TPX": {"tpIdx": U1},  # used with payload keyword
     "CFG-TXSLOT": {},
     "CFG-USB": {},
     "CFG-VALGET": {

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -326,6 +326,19 @@ class FillTest(unittest.TestCase):
         res2 = UBXMessage("NAV", "NAV-SBAS", GET, payload=res1.payload)
         self.assertEqual(str(res1), str(res2))
 
+    def testCFG_TP5(self):  # test CFG-TP5 constructor
+        res1 = UBXMessage("CFG", "CFG-TP5", POLL)
+        res2 = "<UBX(CFG-TP5)>"
+        self.assertEqual(str(res1), res2)
+
+    def testCFG_TP5_TPX(self):  # test CFG-TP5-TPX constructor
+        res1 = UBXMessage("CFG", "CFG-TP5", POLL, payload=b"\x01")
+        res2 = "<UBX(CFG-TP5, tpIdx=1)>"
+        self.assertEqual(str(res1), res2)
+        res1 = UBXMessage("CFG", "CFG-TP5", POLL, payload=b"\x00")
+        res2 = "<UBX(CFG-TP5, tpIdx=0)>"
+        self.assertEqual(str(res1), res2)
+
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

Enhancement to CFG-TP5 POLL construtor to cater for optional tpIdx parameter, which supports polling of either Timepulse 0 or 1.

To access version with tpIdx parameter, use payload keyword (this polls Timepulse 0 or 1):
`msg = UBXMessage("CFG", "CFG-TP5", POLL, payload=b"\x01")`

To access version without tpIdx, omit payload keyword (this only polls Timepulse 0):
`msg = UBXMessage("CFG", "CFG-TP5", POLL)`

Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] Two new test cases added to test_constructor.py

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
