### PR TITLE
RC 1.2.23

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.22"
+    "moduleversion": "1.2.23"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -114,7 +114,13 @@
             "command": "${config:python.defaultInterpreterPath}",
             "args": [
                 "-m",
-                "pytest"
+                "pytest",
+                "--cov-report",
+                "html",
+                "--cov-fail-under",
+                "95",
+                "--cov=${config:distname}",
+                "tests/",
             ],
             "problemMatcher": []
         },

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # pyubx2 Release Notes
 
+### RELEASE 1.2.23
+
+CHANGES:
+
+1. Minimum dependency version updated for pynmeagps and pyrtcm
+1. Minor updates to VSCode task and GitHub actions workflows for pyproject.toml build framework
+1. No other functional changes
 
 ### RELEASE 1.2.22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "UBX protocol parser and generator"
-version = "1.2.22"
+version = "1.2.23"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.7"
@@ -73,7 +73,7 @@ disable = """
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "--cov --cov-report html --cov-report term-missing --cov-fail-under 95"
+addopts = "--cov --cov-report term-missing --cov-fail-under 95"
 pythonpath = ["src"]
 
 [tool.coverage.run]

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.22"
+__version__ = "1.2.23"


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

RELEASE 1.2.23

CHANGES:

1. Minimum dependency version updated for pynmeagps and pyrtcm.
2. Minor updates to VSCode task and GitHub actions workflows for pyproject.toml build framework.
3. No other functional changes.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] no tests changed

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
