### PR TITLE
Rc 1.2.25

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,6 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.24",
+    "moduleversion": "1.2.25",
     "sarif-viewer.connectToGithubCodeScanning": "off"
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # pyubx2 Release Notes
 
+### RELEASE CANDIDATE 1.2.25
+
+ENHANCEMENTS:
+
+1. CFG-VALSET parsing enhanced to match CFG-VALGET as key value pairs rather than a simple array of bytes:
+
+    - Old: <UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, ...>
+    - New: <UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>
+
 ### RELEASE 1.2.24
 
 ENHANCEMENTS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "UBX protocol parser and generator"
-version = "1.2.24"
+version = "1.2.25"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.24"
+__version__ = "1.2.25"

--- a/src/pyubx2/ubxmessage.py
+++ b/src/pyubx2/ubxmessage.py
@@ -186,12 +186,11 @@ class UBXMessage:
 
         index.append(0)  # add a (nested) group index
         numr, attd = att  # number of repeats, attribute dictionary
-        # if CFG-VALGET message, use dedicated method to
+        # if CFG-VALGET or CFG-VALSET message, use dedicated method to
         # parse as configuration key value pairs
-        if (
-            self._ubxClass == b"\x06"
-            and self._ubxID == b"\x8b"
-            and self._mode == ubt.GET
+        if self._ubxClass == b"\x06" and (
+            (self._ubxID == b"\x8b" and self._mode == ubt.GET)
+            or (self._ubxID == b"\x8a" and self._mode == ubt.SET)
         ):
             self._set_attribute_cfgval(offset, **kwargs)
         else:
@@ -443,7 +442,7 @@ class UBXMessage:
 
     def _set_attribute_cfgval(self, offset: int, **kwargs):
         """
-        Parse CFG-VALGET payload to set of configuration
+        Parse CFG-VALGET / CFG-VALSET payload to set of configuration
         key value pairs.
 
         :param int offset: payload offset

--- a/tests/test_configdb.py
+++ b/tests/test_configdb.py
@@ -54,7 +54,8 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(str(res), EXPECTED_RESULT)
 
     def testFill_CFGVALSET(self):  #  test CFG-VALSET SET constructor
-        EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>"
+        # EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>"
+        EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>"
         res = UBXMessage(
             "CFG",
             "CFG-VALSET",

--- a/tests/test_configdb.py
+++ b/tests/test_configdb.py
@@ -54,7 +54,6 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(str(res), EXPECTED_RESULT)
 
     def testFill_CFGVALSET(self):  #  test CFG-VALSET SET constructor
-        # EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>"
         EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>"
         res = UBXMessage(
             "CFG",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -351,7 +351,6 @@ class ExceptionTest(unittest.TestCase):
             "Unknown message type clsid (.*), msgid (.*), mode GET\n"
             + "Check 'msgmode' keyword argument is appropriate for data stream"
         )
-        # EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>"
         EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>"
         res = UBXMessage(
             "CFG",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -351,7 +351,8 @@ class ExceptionTest(unittest.TestCase):
             "Unknown message type clsid (.*), msgid (.*), mode GET\n"
             + "Check 'msgmode' keyword argument is appropriate for data stream"
         )
-        EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>"
+        # EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>"
+        EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>"
         res = UBXMessage(
             "CFG",
             "CFG-VALSET",

--- a/tests/test_specialcases.py
+++ b/tests/test_specialcases.py
@@ -281,8 +281,7 @@ class SpecialTest(unittest.TestCase):
         self.assertEqual(
             str(res),
             "<UBX(CFG-VALSET, version=0, ram=1, bbr=0, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>"
-            # "<UBX(CFG-VALSET, version=0, ram=1, bbr=0, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>",
-        )
+            )
 
     def testConfigSet2(
         self,
@@ -292,8 +291,7 @@ class SpecialTest(unittest.TestCase):
         self.assertEqual(
             str(res),
             "<UBX(CFG-VALSET, version=1, ram=0, bbr=1, flash=0, action=1, reserved0=0, CFG_UART1_BAUDRATE=9600, CFG_UART2_BAUDRATE=115200)>"
-            # "<UBX(CFG-VALSET, version=1, ram=0, bbr=1, flash=0, action=1, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0, cfgData_09=1, cfgData_10=0, cfgData_11=83, cfgData_12=64, cfgData_13=0, cfgData_14=194, cfgData_15=1, cfgData_16=0)>",
-        )
+            )
 
     def testConfigDel(self):  # test creation of CFG-VALSET message with single key
         keys = [

--- a/tests/test_specialcases.py
+++ b/tests/test_specialcases.py
@@ -280,7 +280,8 @@ class SpecialTest(unittest.TestCase):
         res = UBXMessage.config_set(ubxcdb.SET_LAYER_RAM, ubxcdb.TXN_NONE, cfgData)
         self.assertEqual(
             str(res),
-            "<UBX(CFG-VALSET, version=0, ram=1, bbr=0, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>",
+            "<UBX(CFG-VALSET, version=0, ram=1, bbr=0, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>"
+            # "<UBX(CFG-VALSET, version=0, ram=1, bbr=0, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0)>",
         )
 
     def testConfigSet2(
@@ -290,7 +291,8 @@ class SpecialTest(unittest.TestCase):
         res = UBXMessage.config_set(ubxcdb.SET_LAYER_BBR, ubxcdb.TXN_START, cfgData)
         self.assertEqual(
             str(res),
-            "<UBX(CFG-VALSET, version=1, ram=0, bbr=1, flash=0, action=1, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0, cfgData_09=1, cfgData_10=0, cfgData_11=83, cfgData_12=64, cfgData_13=0, cfgData_14=194, cfgData_15=1, cfgData_16=0)>",
+            "<UBX(CFG-VALSET, version=1, ram=0, bbr=1, flash=0, action=1, reserved0=0, CFG_UART1_BAUDRATE=9600, CFG_UART2_BAUDRATE=115200)>"
+            # "<UBX(CFG-VALSET, version=1, ram=0, bbr=1, flash=0, action=1, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, cfgData_06=37, cfgData_07=0, cfgData_08=0, cfgData_09=1, cfgData_10=0, cfgData_11=83, cfgData_12=64, cfgData_13=0, cfgData_14=194, cfgData_15=1, cfgData_16=0)>",
         )
 
     def testConfigDel(self):  # test creation of CFG-VALSET message with single key


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

RELEASE CANDIDATE 1.2.25

ENHANCEMENTS:

1. CFG-VALSET parsing enhanced to match CFG-VALGET as key value pairs rather than a simple array of bytes:
    - Old: <UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, cfgData_01=1, cfgData_02=0, cfgData_03=82, cfgData_04=64, cfgData_05=128, ...>
    - New: <UBX(CFG-VALSET, version=0, ram=1, bbr=1, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>


## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] streaming tests updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
