### PR TITLE
Rc 1.2.32

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.31",
+    "moduleversion": "1.2.32",
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 # pyubx2 Release Notes
 
-### RELEASE CANDIDATE 1.2.31
+### RELEASE CANDIDATE 1.2.32
+
+### RELEASE 1.2.31
 
 ENHANCEMENTS:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ### RELEASE CANDIDATE 1.2.32
 
+ENHANCEMENTS: 
+
+1. Cater for legacy "BD" (Beidou) NMEA Talker ID.
+
 ### RELEASE 1.2.31
 
 ENHANCEMENTS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyubx2"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "UBX protocol parser and generator"
-version = "1.2.31"
+version = "1.2.32"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 
-dependencies = ["pynmeagps >= 1.0.28", "pyrtcm >= 1.0.13"]
+dependencies = ["pynmeagps >= 1.0.29", "pyrtcm >= 1.0.13"]
 
 [project.urls]
 homepage = "https://www.semuconsulting.com/pyubx2/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 
-dependencies = ["pynmeagps >= 1.0.28", "pyrtcm >= 1.0.12"]
+dependencies = ["pynmeagps >= 1.0.28", "pyrtcm >= 1.0.13"]
 
 [project.urls]
 homepage = "https://www.semuconsulting.com/pyubx2/"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.31"
+__version__ = "1.2.32"

--- a/src/pyubx2/ubxhelpers.py
+++ b/src/pyubx2/ubxhelpers.py
@@ -14,10 +14,12 @@ import struct
 from datetime import datetime, timedelta
 from math import cos, pi, sin
 
+from pynmeagps.nmeatypes_core import NMEA_HDR
+
 import pyubx2.exceptions as ube
 import pyubx2.ubxtypes_configdb as ubcdb
 import pyubx2.ubxtypes_core as ubt
-from pyubx2.ubxtypes_core import GNSSLIST, NMEA_HDR, UBX_HDR
+from pyubx2.ubxtypes_core import GNSSLIST, UBX_HDR
 
 
 def att2idx(att: str) -> int:

--- a/src/pyubx2/ubxreader.py
+++ b/src/pyubx2/ubxreader.py
@@ -22,7 +22,7 @@ from socket import socket
 
 import pynmeagps.exceptions as nme
 import pyrtcm.exceptions as rte
-from pynmeagps import NMEAReader
+from pynmeagps import NMEA_HDR, NMEAReader
 from pyrtcm import RTCMReader
 
 from pyubx2.exceptions import (
@@ -38,7 +38,6 @@ from pyubx2.ubxtypes_core import (
     ERR_LOG,
     ERR_RAISE,
     GET,
-    NMEA_HDR,
     NMEA_PROTOCOL,
     RTCM3_PROTOCOL,
     U2,

--- a/src/pyubx2/ubxtypes_core.py
+++ b/src/pyubx2/ubxtypes_core.py
@@ -9,7 +9,6 @@ Information sourced from public domain u-blox Interface Specifications © 2013-2
 """
 
 UBX_HDR = b"\xb5\x62"
-NMEA_HDR = [b"\x24\x47", b"\x24\x50"]
 GET = 0
 SET = 1
 POLL = 2


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

ENHANCEMENTS:

1. Add support for legacy "BD" (Beidou) NMEA Talker ID.
1.  Min version of pynmeagps updated to 1.0.29.
1. Min version of pyrtcm updated to 1.0.13.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] Test A

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
