### PR TITLE
RC 1.2.34

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.33",
+    "moduleversion": "1.2.34",
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ### RELEASE CANDIDATE 1.2.34
 
+ENHANCEMENTS
+
+1. Cater for NMEA streams with LF (b"\x0a") rather than CRLF (b"\x0d\x0a") message terminators.
+
 ### RELEASE 1.2.33
 
 ENHANCEMENTS: 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # pyubx2 Release Notes
 
+### RELEASE CANDIDATE 1.2.34
+
 ### RELEASE 1.2.33
 
 ENHANCEMENTS: 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 ENHANCEMENTS
 
 1. Cater for NMEA streams with LF (b"\x0a") rather than CRLF (b"\x0d\x0a") message terminators.
+2. Update string representation of NOMINAL payload definitions to "<(IDENTITY-NOMINAL, payload="b\x99")>".
 
 ### RELEASE 1.2.33
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 ENHANCEMENTS
 
 1. Cater for NMEA streams with LF (b"\x0a") rather than CRLF (b"\x0d\x0a") message terminators.
-2. Update string representation of NOMINAL payload definitions to "<(IDENTITY-NOMINAL, payload="b\x99")>".
+2. Simplify string representation of NOMINAL (undocumented) payload definitions to "<UBX(IDENTITY-NOMINAL, payload="b\x99...")>".
 
 ### RELEASE 1.2.33
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyubx2"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "UBX protocol parser and generator"
-version = "1.2.33"
+version = "1.2.34"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.33"
+__version__ = "1.2.34"

--- a/src/pyubx2/ubxmessage.py
+++ b/src/pyubx2/ubxmessage.py
@@ -556,7 +556,7 @@ class UBXMessage:
                     pdict = self._get_relposned_version(**kwargs)
                 # Unknown GET message, parsed to nominal definition
                 elif self.identity[-7:] == "NOMINAL":
-                    pdict = ubg.UBX_PAYLOADS_GET["UBX-NOMINAL"]
+                    pdict = {}
                 else:
                     pdict = ubg.UBX_PAYLOADS_GET[self.identity]
             return pdict
@@ -860,6 +860,8 @@ class UBXMessage:
         umsg_name = self.identity
         if self.payload is None:
             return f"<UBX({umsg_name})>"
+        if self.identity[-7:] == "NOMINAL":
+            return f"<UBX({umsg_name}, payload={escapeall(self._payload)})>"
 
         stg = f"<UBX({umsg_name}, "
         for i, att in enumerate(self.__dict__):

--- a/src/pyubx2/ubxreader.py
+++ b/src/pyubx2/ubxreader.py
@@ -248,9 +248,7 @@ class UBXReader:
         """
 
         # read the rest of the NMEA message from the buffer
-        byten = self._stream.readline()  # NMEA protocol is CRLF-terminated
-        if byten[-2:] != b"\x0d\x0a":
-            raise EOFError()
+        byten = self._read_line()  # NMEA protocol is CRLF-terminated
         raw_data = hdr + byten
         # only parse if we need to (filter passes NMEA)
         if (self._protfilter & NMEA_PROTOCOL) and self._parsing:
@@ -304,6 +302,20 @@ class UBXReader:
 
         data = self._stream.read(size)
         if len(data) < size:  # EOF
+            raise EOFError()
+        return data
+
+    def _read_line(self) -> bytes:
+        """
+        Read bytes until LF (0x0a) terminator.
+
+        :return: bytes
+        :rtype: bytes
+        :raises: EOFError if stream ends prematurely
+        """
+
+        data = self._stream.readline()  # NMEA protocol is CRLF-terminated
+        if data[-1:] != b"\x0a":
             raise EOFError()
         return data
 

--- a/tests/test_specialcases.py
+++ b/tests/test_specialcases.py
@@ -280,8 +280,8 @@ class SpecialTest(unittest.TestCase):
         res = UBXMessage.config_set(ubxcdb.SET_LAYER_RAM, ubxcdb.TXN_NONE, cfgData)
         self.assertEqual(
             str(res),
-            "<UBX(CFG-VALSET, version=0, ram=1, bbr=0, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>"
-            )
+            "<UBX(CFG-VALSET, version=0, ram=1, bbr=0, flash=0, action=0, reserved0=0, CFG_UART1_BAUDRATE=9600)>",
+        )
 
     def testConfigSet2(
         self,
@@ -290,8 +290,8 @@ class SpecialTest(unittest.TestCase):
         res = UBXMessage.config_set(ubxcdb.SET_LAYER_BBR, ubxcdb.TXN_START, cfgData)
         self.assertEqual(
             str(res),
-            "<UBX(CFG-VALSET, version=1, ram=0, bbr=1, flash=0, action=1, reserved0=0, CFG_UART1_BAUDRATE=9600, CFG_UART2_BAUDRATE=115200)>"
-            )
+            "<UBX(CFG-VALSET, version=1, ram=0, bbr=1, flash=0, action=1, reserved0=0, CFG_UART1_BAUDRATE=9600, CFG_UART2_BAUDRATE=115200)>",
+        )
 
     def testConfigDel(self):  # test creation of CFG-VALSET message with single key
         keys = [
@@ -368,15 +368,15 @@ class SpecialTest(unittest.TestCase):
         self.assertEqual(str(msg), EXPECTED_RESULT)
 
     def testUnknownClassID(self):  # test for unknown class and id
-        EXPECTED_RESULT = (
-            "<UBX(UNKNOWN-5566-NOMINAL, data_01=b'\\x33', data_02=b'\\x44')>"
-        )
+        EXPECTED_RESULT = "<UBX(UNKNOWN-5566-NOMINAL, payload=b'\\x33\\x44')>"
         msg = UBXReader.parse(b"\xb5b\x55\x66\x02\x00\x33\x44\x34\xae")
+        # print(msg)
         self.assertEqual(str(msg), EXPECTED_RESULT)
 
     def testUnknownID(self):  # test for known class, unknown id
-        EXPECTED_RESULT = "<UBX(DBG-0c66-NOMINAL, data_01=b'\\x33', data_02=b'\\x44')>"
-        msg = UBXReader.parse(b"\xb5b\x0c\x66\x02\x00\x33\x44\xeb\xf8")
+        EXPECTED_RESULT = "<UBX(DBG-0c66-NOMINAL, payload=b'\\x55\\x66')>"
+        msg = UBXReader.parse(b"\xb5b\x0c\x66\x02\x00\x55\x66\x2f\x5e")
+        # print(msg)
         self.assertEqual(str(msg), EXPECTED_RESULT)
 
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -544,7 +544,7 @@ class StreamTest(unittest.TestCase):
             if not isinstance(parsed, str):
                 print(parsed)
         output = self.restoreio().split("\n")
-        print(output)
+        # print(output)
         self.assertEqual(EXPECTED_RESULTS, output)
 
     def testUBXITERATE_ERR3(
@@ -647,8 +647,10 @@ class StreamTest(unittest.TestCase):
     def testDEBUG(
         self,
     ):  # test stream of UBX DEBUG messages
-        EXPECTED_RESULTS1 = "<UBX(CFG-VALGET, version=1, layer=0, position=0, CFG_0x10010001=b'\\x00', CFG_0x10010101=b'\\x00', CFG_0x10040009=b'\\x00', CFG_TP_TP1_ENA=1, CFG_TP_SYNC_GNSS_TP1=1, CFG_TP_USE_LOCKED_TP1=1, CFG_TP_ALIGN_TO_TOW_TP1=1, CFG_TP_POL_TP1=1, CFG_0x10110012=b'\\x00', CFG_NAVSPG_INIFIX3D=0, CFG_0x10110014=b'\\x01', CFG_0x10110015=b'\\x01', CFG_0x10110016=b'\\x01', CFG_0x10110018=b'\\x01', CFG_0x1011001b=b'\\x00', CFG_NAVSPG_ACKAIDING=0, CFG_0x10110046=b'\\x01', CFG_0x10110052=b'\\x00', CFG_0x10110053=b'\\x00', CFG_NAVSPG_USE_USRDAT=0, CFG_0x10110081=b'\\x00', CFG_0x10110082=b'\\x00', CFG_0x10110083=b'\\x00', CFG_NAVSPG_PL_ENA=1, CFG_0x10140051=b'\\x00', CFG_0x10140052=b'\\x00', CFG_0x10140053=b'\\x00', CFG_0x10140061=b'\\x01', CFG_NAV2_OUT_ENABLED=0, CFG_NAV2_SBAS_USE_INTEGRITY=0, CFG_0x10210005=b'\\x00', CFG_ODO_USE_ODO=0, CFG_ODO_USE_COG=0, CFG_ODO_OUTLPVEL=0, CFG_ODO_OUTLPCOG=0, CFG_GEOFENCE_USE_PIO=0, CFG_GEOFENCE_USE_FENCE1=0, CFG_GEOFENCE_USE_FENCE2=0, CFG_GEOFENCE_USE_FENCE3=0, CFG_GEOFENCE_USE_FENCE4=0, CFG_0x10250001=b'\\x01', CFG_SIGNAL_GPS_L1CA_ENA=1, CFG_SIGNAL_GPS_L2C_ENA=1, CFG_SIGNAL_SBAS_L1CA_ENA=1, CFG_SIGNAL_GAL_E1_ENA=1, CFG_SIGNAL_GAL_E5B_ENA=1, CFG_SIGNAL_BDS_B1_ENA=1, CFG_SIGNAL_BDS_B2_ENA=1, CFG_SIGNAL_QZSS_L1CA_ENA=1, CFG_SIGNAL_QZSS_L1S_ENA=0, CFG_SIGNAL_QZSS_L2C_ENA=1, CFG_SIGNAL_GLO_L1_ENA=1, CFG_SIGNAL_GLO_L2_ENA=1, CFG_SIGNAL_GPS_ENA=1, CFG_SIGNAL_SBAS_ENA=1, CFG_SIGNAL_GAL_ENA=1, CFG_SIGNAL_BDS_ENA=1, CFG_SIGNAL_QZSS_ENA=1, CFG_SIGNAL_GLO_ENA=1, CFG_0x10310027=b'\\x01', CFG_0x10330001=b'\\x00', CFG_0x10330002=b'\\x00', CFG_0x10330003=b'\\x00', CFG_0x10330011=b'\\x00')>"
-        EXPECTED_RESULTS2 = "<UBX(DBG-0c4b-NOMINAL, data_01=b'\\x00', data_02=b'\\x00', data_03=b'\\x64', data_04=b'\\x00', data_05=b'\\x26', data_06=b'\\x00', data_07=b'\\x01', data_08=b'\\x00', data_09=b'\\x33', data_10=b'\\x10', data_11=b'\\x00', data_12=b'\\x02', data_13=b'\\x00', data_14=b'\\x33', data_15=b'\\x10', data_16=b'\\x00', data_17=b'\\x03', data_18=b'\\x00', data_19=b'\\x33', data_20=b'\\x10', data_21=b'\\x00', data_22=b'\\x11', data_23=b'\\x00', data_24=b'\\x33', data_25=b'\\x10', data_26=b'\\x00', data_27=b'\\x21', data_28=b'\\x00', data_29=b'\\x33', data_30=b'\\x10', data_31=b'\\x01', data_32=b'\\x01', data_33=b'\\x00', data_34=b'\\x34', data_35=b'\\x10', data_36=b'\\x00', data_37=b'\\x02', data_38=b'\\x00', data_39=b'\\x34', data_40=b'\\x10', data_41=b'\\x00', data_42=b'\\x03', data_43=b'\\x00', data_44=b'\\x34', data_45=b'\\x10', data_46=b'\\x01', data_47=b'\\x04', data_48=b'\\x00', data_49=b'\\x34', data_50=b'\\x10', data_51=b'\\x00', data_52=b'\\x11', data_53=b'\\x00', data_54=b'\\x34', data_55=b'\\x10', data_56=b'\\x00', data_57=b'\\x14', data_58=b'\\x00', data_59=b'\\x34', data_60=b'\\x10', data_61=b'\\x00', data_62=b'\\x01', data_63=b'\\x00', data_64=b'\\x35', data_65=b'\\x10', data_66=b'\\x00', data_67=b'\\x02', data_68=b'\\x00', data_69=b'\\x35', data_70=b'\\x10', data_71=b'\\x00', data_72=b'\\x03', data_73=b'\\x00', data_74=b'\\x35', data_75=b'\\x10', data_76=b'\\x00', data_77=b'\\x04', data_78=b'\\x00', data_79=b'\\x35', data_80=b'\\x10', data_81=b'\\x00', data_82=b'\\x02', data_83=b'\\x00', data_84=b'\\x36', data_85=b'\\x10', data_86=b'\\x00', data_87=b'\\x03', data_88=b'\\x00', data_89=b'\\x36', data_90=b'\\x10', data_91=b'\\x01', data_92=b'\\x04', data_93=b'\\x00', data_94=b'\\x36', data_95=b'\\x10', data_96=b'\\x01', data_97=b'\\x05', data_98=b'\\x00', data_99=b'\\x36', data_100=b'\\x10', data_101=b'\\x00', data_102=b'\\x07', data_103=b'\\x00', data_104=b'\\x36', data_105=b'\\x10', data_106=b'\\x00')>"
+        EXPECTED_RESULTS = [
+            "<UBX(CFG-VALGET, version=1, layer=0, position=0, CFG_0x10010001=b'\\x00', CFG_0x10010101=b'\\x00', CFG_0x10040009=b'\\x00', CFG_TP_TP1_ENA=1, CFG_TP_SYNC_GNSS_TP1=1, CFG_TP_USE_LOCKED_TP1=1, CFG_TP_ALIGN_TO_TOW_TP1=1, CFG_TP_POL_TP1=1, CFG_0x10110012=b'\\x00', CFG_NAVSPG_INIFIX3D=0, CFG_0x10110014=b'\\x01', CFG_0x10110015=b'\\x01', CFG_0x10110016=b'\\x01', CFG_0x10110018=b'\\x01', CFG_0x1011001b=b'\\x00', CFG_NAVSPG_ACKAIDING=0, CFG_0x10110046=b'\\x01', CFG_0x10110052=b'\\x00', CFG_0x10110053=b'\\x00', CFG_NAVSPG_USE_USRDAT=0, CFG_0x10110081=b'\\x00', CFG_0x10110082=b'\\x00', CFG_0x10110083=b'\\x00', CFG_NAVSPG_PL_ENA=1, CFG_0x10140051=b'\\x00', CFG_0x10140052=b'\\x00', CFG_0x10140053=b'\\x00', CFG_0x10140061=b'\\x01', CFG_NAV2_OUT_ENABLED=0, CFG_NAV2_SBAS_USE_INTEGRITY=0, CFG_0x10210005=b'\\x00', CFG_ODO_USE_ODO=0, CFG_ODO_USE_COG=0, CFG_ODO_OUTLPVEL=0, CFG_ODO_OUTLPCOG=0, CFG_GEOFENCE_USE_PIO=0, CFG_GEOFENCE_USE_FENCE1=0, CFG_GEOFENCE_USE_FENCE2=0, CFG_GEOFENCE_USE_FENCE3=0, CFG_GEOFENCE_USE_FENCE4=0, CFG_0x10250001=b'\\x01', CFG_SIGNAL_GPS_L1CA_ENA=1, CFG_SIGNAL_GPS_L2C_ENA=1, CFG_SIGNAL_SBAS_L1CA_ENA=1, CFG_SIGNAL_GAL_E1_ENA=1, CFG_SIGNAL_GAL_E5B_ENA=1, CFG_SIGNAL_BDS_B1_ENA=1, CFG_SIGNAL_BDS_B2_ENA=1, CFG_SIGNAL_QZSS_L1CA_ENA=1, CFG_SIGNAL_QZSS_L1S_ENA=0, CFG_SIGNAL_QZSS_L2C_ENA=1, CFG_SIGNAL_GLO_L1_ENA=1, CFG_SIGNAL_GLO_L2_ENA=1, CFG_SIGNAL_GPS_ENA=1, CFG_SIGNAL_SBAS_ENA=1, CFG_SIGNAL_GAL_ENA=1, CFG_SIGNAL_BDS_ENA=1, CFG_SIGNAL_QZSS_ENA=1, CFG_SIGNAL_GLO_ENA=1, CFG_0x10310027=b'\\x01', CFG_0x10330001=b'\\x00', CFG_0x10330002=b'\\x00', CFG_0x10330003=b'\\x00', CFG_0x10330011=b'\\x00')>",
+            "<UBX(DBG-0c4b-NOMINAL, payload=b'\\x00\\x00\\x64\\x00\\x26\\x00\\x01\\x00\\x33\\x10\\x00\\x02\\x00\\x33\\x10\\x00\\x03\\x00\\x33\\x10\\x00\\x11\\x00\\x33\\x10\\x00\\x21\\x00\\x33\\x10\\x01\\x01\\x00\\x34\\x10\\x00\\x02\\x00\\x34\\x10\\x00\\x03\\x00\\x34\\x10\\x01\\x04\\x00\\x34\\x10\\x00\\x11\\x00\\x34\\x10\\x00\\x14\\x00\\x34\\x10\\x00\\x01\\x00\\x35\\x10\\x00\\x02\\x00\\x35\\x10\\x00\\x03\\x00\\x35\\x10\\x00\\x04\\x00\\x35\\x10\\x00\\x02\\x00\\x36\\x10\\x00\\x03\\x00\\x36\\x10\\x01\\x04\\x00\\x36\\x10\\x01\\x05\\x00\\x36\\x10\\x00\\x07\\x00\\x36\\x10\\x00')>",
+        ]
         i = 0
         raw = 0
         ubxreader = UBXReader(self.streamDEBUG)
@@ -658,11 +660,11 @@ class StreamTest(unittest.TestCase):
             if raw is not None:
                 res = str(parsed)
                 if i == 5:
-                    res1 = res
+                    # print(res)
+                    self.assertEqual(res, EXPECTED_RESULTS[0])
                 if i == 188:
-                    res2 = res
-        self.assertEqual(res1, EXPECTED_RESULTS1)
-        self.assertEqual(res2, EXPECTED_RESULTS2)
+                    # print(res.replace("\\", "\\\\"))
+                    self.assertEqual(res, EXPECTED_RESULTS[1])
         self.assertEqual(i, 189)
 
 


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

1. Cater for NMEA streams with LF (b"\x0a") rather than CRLF (b"\x0d\x0a") message terminators.
1. Simplify string representation of NOMINAL (undocumented) payload definitions to "<UBX(IDENTITY-NOMINAL, payload="b\x99...")>".

Fixes #131 

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] NMEA Streaming tests updated
- [x] UBX Nominal payload tests updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
