### PR TITLE
Rc 1.2.40

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.39",
+    "moduleversion": "1.2.40",
 }

--- a/README.md
+++ b/README.md
@@ -118,30 +118,30 @@ Example -  Serial input. This example will output both UBX and NMEA messages:
 ```python
 from serial import Serial
 from pyubx2 import UBXReader
-stream = Serial('/dev/tty.usbmodem14101', 9600, timeout=3)
-ubr = UBXReader(stream)
-(raw_data, parsed_data) = ubr.read()
-print(parsed_data)
+with Serial('/dev/tty.usbmodem14101', 9600, timeout=3) as stream:
+  ubr = UBXReader(stream)
+  raw_data, parsed_data = ubr.read()
+  print(parsed_data)
 ```
 
 Example - File input (using iterator). This will only output UBX data:
 ```python
 from pyubx2 import UBXReader
-stream = open('ubxdata.bin', 'rb')
-ubr = UBXReader(stream, protfilter=2)
-for (raw_data, parsed_data) in ubr:
-  print(parsed_data)
+with open('ubxdata.bin', 'rb') as stream:
+  ubr = UBXReader(stream, protfilter=2)
+  for (raw_data, parsed_data) in ubr:
+    print(parsed_data)
 ```
 
 Example - Socket input (using iterator). This will output UBX, NMEA and RTCM3 data:
 ```python
 import socket
 from pyubx2 import UBXReader
-stream = socket.socket(socket.AF_INET, socket.SOCK_STREAM):
-stream.connect(("localhost", 50007))
-ubr = UBXReader(stream, protfilter=7)
-for (raw_data, parsed_data) in ubr:
-  print(parsed_data)
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as stream:
+  stream.connect(("localhost", 50007))
+  ubr = UBXReader(stream, protfilter=7)
+  for (raw_data, parsed_data) in ubr:
+    print(parsed_data)
 ```
 
 ---
@@ -201,11 +201,11 @@ The `payload` attribute always contains the raw payload as bytes. Attributes wit
 **Tip:** To iterate through a repeating group of attributes (*e.g. svid*), the following construct can be used:
 
 ```python
-svids = [] # list of svid values from repeating group
+vals = [] # list of svid values from repeating group
 for i in range(msg.numSV): # numSV = size of repeating group
     svid = getattr(msg, f"svid_{i+1:02d}")
-    svids.append(svid)
-print(svids)
+    vals.append(svid)
+print(vals)
 ```
 
 If the input message class / id is unrecognised (i.e. not publicly documented by u-blox), `pyubx2` will parse the message to a nominal payload definition and append the term 'NOMINAL' to the message identity.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Example - File input (using iterator). This will only output UBX data:
 from pyubx2 import UBXReader
 with open('ubxdata.bin', 'rb') as stream:
   ubr = UBXReader(stream, protfilter=2)
-  for (raw_data, parsed_data) in ubr:
+  for raw_data, parsed_data in ubr:
     print(parsed_data)
 ```
 
@@ -140,7 +140,7 @@ from pyubx2 import UBXReader
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as stream:
   stream.connect(("localhost", 50007))
   ubr = UBXReader(stream, protfilter=7)
-  for (raw_data, parsed_data) in ubr:
+  for raw_data, parsed_data in ubr:
     print(parsed_data)
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 # pyubx2 Release Notes
 
-### RELEASE CANDIDATE 1.2.39
+### RELEASE 1.2.40
+
+ENHANCEMENTS:
+
+1. Internal field naming clarified and docstrings updated - no functional changes.
+
+### RELEASE 1.2.39
 
 FIXES:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyubx2"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "UBX protocol parser and generator"
-version = "1.2.39"
+version = "1.2.40"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 
-dependencies = ["pynmeagps >= 1.0.35", "pyrtcm >= 1.0.19"]
+dependencies = ["pynmeagps >= 1.0.35", "pyrtcm >= 1.0.20"]
 
 [project.urls]
 homepage = "https://www.semuconsulting.com/pyubx2/"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.39"
+__version__ = "1.2.40"

--- a/src/pyubx2/ubxhelpers.py
+++ b/src/pyubx2/ubxhelpers.py
@@ -9,8 +9,6 @@ Created on 15 Dec 2020
 :license: BSD 3-Clause
 """
 
-# pylint: disable=invalid-name
-
 import struct
 from datetime import datetime, timedelta
 from math import cos, pi, sin, trunc
@@ -349,7 +347,7 @@ def nomval(att: str) -> object:
     return val
 
 
-def msgclass2bytes(msgClass: int, msgID: int) -> bytes:
+def msgclass2bytes(msgclass: int, msgid: int) -> bytes:
     """
     Convert message class/id integers to bytes.
 
@@ -360,12 +358,12 @@ def msgclass2bytes(msgClass: int, msgID: int) -> bytes:
 
     """
 
-    msgClass = val2bytes(msgClass, ubt.U1)
-    msgID = val2bytes(msgID, ubt.U1)
-    return (msgClass, msgID)
+    msgclass = val2bytes(msgclass, ubt.U1)
+    msgid = val2bytes(msgid, ubt.U1)
+    return (msgclass, msgid)
 
 
-def msgstr2bytes(msgClass: str, msgID: str) -> bytes:
+def msgstr2bytes(msgclass: str, msgid: str) -> bytes:
     """
     Convert plain text UBX message class to bytes.
 
@@ -378,12 +376,12 @@ def msgstr2bytes(msgClass: str, msgID: str) -> bytes:
     """
 
     try:
-        clsid = key_from_val(ubt.UBX_CLASSES, msgClass)
-        msgid = key_from_val(ubt.UBX_MSGIDS, msgID)[1:2]
+        clsid = key_from_val(ubt.UBX_CLASSES, msgclass)
+        msgid = key_from_val(ubt.UBX_MSGIDS, msgid)[1:2]
         return (clsid, msgid)
     except KeyError as err:
         raise ube.UBXMessageError(
-            f"Undefined message, class {msgClass}, id {msgID}"
+            f"Undefined message, class {msgclass}, id {msgid}"
         ) from err
 
 
@@ -406,7 +404,7 @@ def cfgname2key(name: str) -> tuple:
         ) from err
 
 
-def cfgkey2name(keyID: int) -> tuple:
+def cfgkey2name(keyid: int) -> tuple:
     """
     Return key name and data type for given
     configuration database hexadecimal key.
@@ -422,18 +420,18 @@ def cfgkey2name(keyID: int) -> tuple:
         val = None
         for key, val in ubcdb.UBX_CONFIG_DATABASE.items():
             (kid, typ) = val
-            if keyID == kid:
+            if keyid == kid:
                 return (key, typ)
 
         # undocumented configuration database key
         # type is derived from keyID
-        key = f"CFG_{hex(keyID)}"
-        typ = f"X{ubcdb.UBX_CONFIG_STORSIZE[int(hex(keyID)[2:3])]:03d}"
+        key = f"CFG_{hex(keyid)}"
+        typ = f"X{ubcdb.UBX_CONFIG_STORSIZE[int(hex(keyid)[2:3])]:03d}"
         return (key, typ)
 
     except KeyError as err:
         raise ube.UBXMessageError(
-            f"Invalid configuration database key {hex(keyID)}"
+            f"Invalid configuration database key {hex(keyid)}"
         ) from err
 
 


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

1. Internal field naming clarified and docstrings updated - no functional changes.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
