### PR TITLE
Fix structure of `SEC-SIGLOG`

### DIFF
--- a/src/pyubx2/ubxtypes_get.py
+++ b/src/pyubx2/ubxtypes_get.py
@@ -3434,9 +3434,9 @@ UBX_PAYLOADS_GET = {
                 "timeElapsed": U4,
                 "detectionType": U1,
                 "eventType": U1,
+                "reserved1": U2,
             },
         ),
-        "reserved1": U2,
     },
     "SEC-SIGN": {
         "version": U1,


### PR DESCRIPTION
This PR fixes the `SEC-SIGLOG` message type by moving the reserved bytes into the repeated group as suggested by the interface description (Firmware version 1.40 and 1.50):
https://content.u-blox.com/sites/default/files/documents/u-blox-F9-HPG-1.50_InterfaceDescription_UBXDOC-963802114-12815.pdf

## Testing
I tested this change on a receiver with version 1.50

## Checklist:

- [X] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [X] I have performed a self-review of my own code.
- [X] (*if appropriate*) I have cited my u-blox documentation source(s).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [ ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [X] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
