### PR TITLE
update to v1.2.46

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.45",
+    "moduleversion": "1.2.46",
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pyubx2 Release Notes
 
+### RELEASE 1.2.46
+
+ENHANCEMENTS:
+
+1. Minimum version of pynmeagps updated to 1.0.42 - incorporates additional NMEA sentence definitions and helper functions.
+
 ### RELEASE 1.2.45
 
 ENHANCEMENTS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyubx2"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "UBX protocol parser and generator"
-version = "1.2.45"
+version = "1.2.46"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.45"
+__version__ = "1.2.46"


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

1. Minimum version of pynmeagps updated to 1.0.42 - incorporates additional NMEA sentence definitions and helper functions.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] NMEA stream tests updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
