### PR TITLE
Feat/fix types

### DIFF
--- a/src/pyubx2/ubxtypes_core.py
+++ b/src/pyubx2/ubxtypes_core.py
@@ -78,12 +78,14 @@ U9 = "U009"  # Unsigned Int 9 bytes
 U10 = "U010"  # Unsigned Int 10 bytes
 U11 = "U011"  # Unsigned Int 11 bytes
 U12 = "U012"  # Unsigned Int 12 bytes
+U14 = "U014"  # Unsigned Int 14 bytes
 U15 = "U015"  # Unsigned Int 15 bytes
 U16 = "U016"  # Unsigned Int 16 bytes
 U20 = "U020"  # Unsigned Int 20 bytes
 U22 = "U022"  # Unsigned Int 22 bytes
 U23 = "U023"  # Unsigned Int 23 bytes
 U24 = "U024"  # Unsigned Int 24 bytes
+U27 = "U027"  # Unsigned Int 27 bytes
 U32 = "U032"  # Unsigned Int 32 bytes
 U40 = "U040"  # Unsigned Int 40 bytes
 U64 = "U064"  # Unsigned Int 64 bytes
@@ -184,6 +186,7 @@ UBX_MSGIDS = {
     b"\x06\x3b": "CFG-PM2",
     b"\x06\x86": "CFG-PMS",
     b"\x06\x00": "CFG-PRT",
+    b"\x06\x59": "CFG-PT2",
     b"\x06\x57": "CFG-PWR",
     b"\x06\x08": "CFG-RATE",
     b"\x06\x34": "CFG-RINV",
@@ -292,6 +295,7 @@ UBX_MSGIDS = {
     b"\x0a\x02": "MON-IO",  # deprecated, use MON-COMMS
     b"\x0a\x06": "MON-MSGPP",  # deprecated, use MON-COMMS
     b"\x0a\x27": "MON-PATCH",
+    b"\x0a\x2b": "MON-PT2",
     b"\x0a\x38": "MON-RF",
     b"\x0a\x07": "MON-RXBUF",  # deprecated, use MON-COMMS
     b"\x0a\x21": "MON-RXR",

--- a/src/pyubx2/ubxtypes_get.py
+++ b/src/pyubx2/ubxtypes_get.py
@@ -1824,7 +1824,7 @@ UBX_PAYLOADS_GET = {
         "clkDriftTrk": I4,
         "rtcFreq": U4,
         "postStatus": U4,
-        "group": (
+        "rfGroup": (
             "numRfChn",
             {
                 "rfPga": U1,

--- a/src/pyubx2/ubxtypes_get.py
+++ b/src/pyubx2/ubxtypes_get.py
@@ -57,7 +57,7 @@ from pyubx2.ubxtypes_core import (
     X1,
     X2,
     X4,
-    X24,
+    X24, U27, U14,
 )
 
 UBX_PAYLOADS_GET = {
@@ -1813,6 +1813,46 @@ UBX_PAYLOADS_GET = {
                 "patchData": U4,
             },
         ),
+    },
+    "MON-PT2": {
+        "version": U1,
+        "testMode": U1,
+        "numRfChn": U1,
+        "numSvSigDesc": U1,
+        "testRunTime": U4,
+        "clkDriftAid": I4,
+        "clkDriftTrk": I4,
+        "rtcFreq": U4,
+        "postStatus": U4,
+        "group": (
+            "numRfChn",
+            {
+                "rfPga": U1,
+                "reserved1": U27
+            }
+        ),
+        "satGroup": (
+            "numSvSigDesc", {
+                "gnssId": U1,
+                "svId": U1,
+                "sigId": U1,
+                "accsId": U1,
+                "cnoMin": U2,
+                "cnoMax": U2,
+                "reserved3": U14,
+                "carrPhDevMax": U1,
+                "signalInfo": (X1, {
+                    "ifChnIdValid": U1,
+                    "ifChnId": U2,
+                })
+            }
+        ),
+        "codeLockSuccess": U1,
+        "phaseLockSuccess": U1,
+        "minCodeLockTime": U2,
+        "maxCodeLockTime": U2,
+        "maxPhaseLockTime": U2,
+        "reserved4": U2
     },
     "MON-RF": {
         "version": U1,

--- a/src/pyubx2/ubxtypes_poll.py
+++ b/src/pyubx2/ubxtypes_poll.py
@@ -75,6 +75,7 @@ UBX_PAYLOADS_POLL = {
     "CFG-NVS": {},
     "CFG-ODO": {},
     "CFG-PM2": {},
+    "CFG-PT2": {},
     "CFG-PM": {},
     "CFG-PMS": {},
     "CFG-PRT": {"portID": U1},

--- a/src/pyubx2/ubxtypes_set.py
+++ b/src/pyubx2/ubxtypes_set.py
@@ -248,8 +248,8 @@ UBX_PAYLOADS_SET = {
         "extint": U1,
         "refFreq": U4,
         "refFreqAcc": U4,
-        "group": (
-            1,
+        "sat_identifiers": (
+            "None",  # Dumb way of a group repeating 'n' times
             {
                 "gnssId": U1,
                 "svId": U1,

--- a/src/pyubx2/ubxtypes_set.py
+++ b/src/pyubx2/ubxtypes_set.py
@@ -249,7 +249,7 @@ UBX_PAYLOADS_SET = {
         "refFreq": U4,
         "refFreqAcc": U4,
         "sat_identifiers": (
-            "None",  # Dumb way of a group repeating 'n' times
+            "None",
             {
                 "gnssId": U1,
                 "svId": U1,

--- a/src/pyubx2/ubxtypes_set.py
+++ b/src/pyubx2/ubxtypes_set.py
@@ -235,6 +235,29 @@ UBX_PAYLOADS_SET = {
     "CFG-PM2": UBX_GET["CFG-PM2"],
     "CFG-PMS": UBX_GET["CFG-PMS"],
     "CFG-PRT": UBX_GET["CFG-PRT"],
+    "CFG-PT2": {
+        "version": U1,
+        "activate": (
+            X1,
+            {
+                "enable": U1,
+                "reserved0": U5,
+                "lnaMode": U2
+            }
+        ),
+        "extint": U1,
+        "refFreq": U4,
+        "refFreqAcc": U4,
+        "group": (
+            1,
+            {
+                "gnssId": U1,
+                "svId": U1,
+                "sigId": U1,
+                "accsId": U1
+            },
+        )
+    },
     "CFG-PWR": UBX_GET["CFG-PWR"],
     "CFG-RATE": UBX_GET["CFG-RATE"],
     "CFG-RINV": UBX_GET["CFG-RINV"],

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -11,7 +11,7 @@ Created on 21 Oct 2020
 
 import unittest
 
-from pyubx2 import UBXMessage, UBXReader, GET, SET, POLL
+from pyubx2 import UBXMessage, UBXReader, GET, SET, POLL, SETPOLL
 
 
 class FillTest(unittest.TestCase):
@@ -325,6 +325,25 @@ class FillTest(unittest.TestCase):
         )
         res2 = UBXMessage("NAV", "NAV-SBAS", GET, payload=res1.payload)
         self.assertEqual(str(res1), str(res2))
+
+    def testCFG_PT2(self):  # test CFG-PT2 constructor
+        res1 = UBXMessage("CFG", "CFG-PT2", SET,
+                          version=2, enable=1, lnaMode=0x2, extint=0x01, reAcqCno=25, refFreq=0x12345678, refFreqAcc=1234567,
+                          gnssId_01=1, svId_01=2, sigId_01=3, accsId_01=4
+                          )
+        encoded = res1.serialize()
+        self.assertEqual(encoded.hex(), "b56206590f000281017856341287d61200010203047f7a")
+        decoded = UBXReader.parse(encoded, msgmode=SETPOLL)
+        self.assertEqual(str(decoded), str(res1))
+
+    def testMON_PT2(self):  # test CFG-PT2 constructor
+        res1 = UBXMessage("MON", "MON-PT2", GET, numRfChn=2, numSvSigDesc=1)
+        encoded = res1.serialize()
+        self.assertEqual(encoded.hex(), "b5620a2b7200000002010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000aa3a")
+        decoded = UBXReader.parse(encoded, msgmode=GET)
+        print(str(decoded))
+        self.assertEqual(str(decoded), str(res1))
+
 
     def testCFG_TP5(self):  # test CFG-TP5 constructor
         res1 = UBXMessage("CFG", "CFG-TP5", POLL)


### PR DESCRIPTION
- I think there was an issue in the way keywords args were inserted into the payload for repeated groups of `n` repetitions. Ie user defined, rather than determined by a variable. Using the recommended method of defining repeated (shown below) didn't work. They'd never show up in the payload
```
gnssId_01 = 1
svId_01 = 2
gnssId_02 = 3
svId_02 = 4
```
New usage looks like this:
```
gnssId = [1, 3]
svId = [2, 4]
```
The method which calculates payload length is simpler and seems to work. (The message still has the `_XY` identifier under the hood though).

