### PR TITLE
RC 1.2.48

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ If you're adding new UBX message definitions for Generation 9+ devices, please c
 - [ ] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
 - [ ] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
 - [ ] I have performed a self-review of my own code.
-- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
+- [ ] (*if appropriate*) I have cited my PUBLIC DOMAIN u-blox documentation source(s).
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have made corresponding changes to the documentation.
 - [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.47",
+    "moduleversion": "1.2.48",
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pyubx2 Release Notes
 
+### RELEASE 1.2.48
+
+FIXES:
+
+1. Allow signed values in X bitfields (despite Interface Manual saying they're unsigned) - allows user to enter -ve values for ESF-MEAS.dataField.
+
 ### RELEASE 1.2.47
 
 ENHANCEMENTS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyubx2"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "UBX protocol parser and generator"
-version = "1.2.47"
+version = "1.2.48"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.47"
+__version__ = "1.2.48"

--- a/src/pyubx2/ubxmessage.py
+++ b/src/pyubx2/ubxmessage.py
@@ -348,7 +348,7 @@ class UBXMessage:
 
         # update payload
         if "payload" not in kwargs:
-            self._payload += bitfield.to_bytes(bsiz, "little")
+            self._payload += bitfield.to_bytes(bsiz, "little", signed=True)
 
         return (offset + bsiz, index)
 

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -7,6 +7,7 @@ Created on 21 Oct 2020
 
 @author: semuadmin
 """
+
 # pylint: disable=line-too-long, invalid-name, missing-docstring, no-member
 
 import unittest
@@ -330,6 +331,32 @@ class FillTest(unittest.TestCase):
         res1 = UBXMessage("CFG", "CFG-TP5", POLL)
         res2 = "<UBX(CFG-TP5)>"
         self.assertEqual(str(res1), res2)
+
+    def testESF_MEAS_POS(self):  # test ESF-MEAS with +ve value
+        EXPECTED_RESULT = "<UBX(ESF-MEAS, timeTag=1000, timeMarkSent=0, timeMarkEdge=0, calibTtagValid=0, numMeas=1, id=0, dataField_01=10, dataType_01=11)>"
+        res = UBXMessage(
+            "ESF",
+            "ESF-MEAS",
+            SET,
+            timeTag=1000,
+            numMeas=1,
+            dataField_01=10,
+            dataType_01=11,
+        )
+        self.assertEqual(str(res), EXPECTED_RESULT)
+
+    def testESF_MEAS_NEG(self):  # test ESF-MEAS with -ve value
+        EXPECTED_RESULT = "<UBX(ESF-MEAS, timeTag=1000, timeMarkSent=0, timeMarkEdge=0, calibTtagValid=0, numMeas=1, id=0, dataField_01=-10, dataType_01=11)>"
+        res = UBXMessage(
+            "ESF",
+            "ESF-MEAS",
+            SET,
+            timeTag=1000,
+            numMeas=1,
+            dataField_01=-10,
+            dataType_01=11,
+        )
+        self.assertEqual(str(res), EXPECTED_RESULT)
 
     def testCFG_TP5_TPX(self):  # test CFG-TP5-TPX constructor
         res1 = UBXMessage("CFG", "CFG-TP5", POLL, payload=b"\x01")

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -345,16 +345,18 @@ class FillTest(unittest.TestCase):
         )
         self.assertEqual(str(res), EXPECTED_RESULT)
 
-    def testESF_MEAS_NEG(self):  # test ESF-MEAS with -ve value
-        EXPECTED_RESULT = "<UBX(ESF-MEAS, timeTag=1000, timeMarkSent=0, timeMarkEdge=0, calibTtagValid=0, numMeas=1, id=0, dataField_01=-10, dataType_01=11)>"
+    def testESF_MEAS_NEG(self):  # test ESF-MEAS with -ve value and bitmask
+        EXPECTED_RESULT = "<UBX(ESF-MEAS, timeTag=1000, timeMarkSent=0, timeMarkEdge=0, calibTtagValid=0, numMeas=2, id=0, dataField_01=-10, dataType_01=11, dataField_02=8388618, dataType_02=12)>"
         res = UBXMessage(
             "ESF",
             "ESF-MEAS",
             SET,
             timeTag=1000,
-            numMeas=1,
+            numMeas=2,
             dataField_01=-10,
             dataType_01=11,
+            dataField_02=0b100000000000000000001010,
+            dataType_02=12,
         )
         self.assertEqual(str(res), EXPECTED_RESULT)
 


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

1. Allow signed values in X bitfields (despite Interface Manual saying they're unsigned) - e.g. allows user to enter -ve values for ESF-MEAS.dataField without having to do external 2's comp conversion.

Fixes #163 

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] tests added to test_constructor.py

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
