### PR TITLE
RC 1.2.48

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.47",
+    "moduleversion": "1.2.48",
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # pyubx2 Release Notes
 
+### RELEASE 1.2.48
+
+ENHANCEMENTS:
+
 ### RELEASE 1.2.47
 
 ENHANCEMENTS:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ENHANCEMENTS:
 
+1. Add helper methods `val2twoscomp` and `val2signmag` to convert signed integer to appropriate two's complement or sign magnitude binary representation.
+
 ### RELEASE 1.2.47
 
 ENHANCEMENTS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyubx2"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "UBX protocol parser and generator"
-version = "1.2.47"
+version = "1.2.48"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.47"
+__version__ = "1.2.48"

--- a/src/pyubx2/ubxhelpers.py
+++ b/src/pyubx2/ubxhelpers.py
@@ -622,3 +622,31 @@ def process_monver(msg: object) -> dict:
     verdata["gnss"] = gnss_supported
 
     return verdata
+
+
+def val2twoscomp(val: int, att: str) -> int:
+    """
+    Convert signed integer to two's complement binary representation.
+
+    :param int val: value
+    :param str att: attribute type e.g. "U024"
+    :return: two's complement representation of value
+    :rtype: int
+    """
+
+    return val & pow(2, attsiz(att)) - 1
+
+
+def val2signmag(val: int, att: str) -> int:
+    """
+    Convert signed integer to sign magnitude binary representation.
+
+    High-order bit represents sign (0 +ve, 1 -ve).
+
+    :param int val: value
+    :param str att: attribute type e.g. "U024"
+    :return: sign magnitude representation of value
+    :rtype: int
+    """
+
+    return (abs(val) & pow(2, attsiz(att)) - 1) | ((1 if val < 0 else 0) << attsiz(att))

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -40,6 +40,8 @@ from pyubx2.ubxhelpers import (
     utc2itow,
     val2bytes,
     val2sphp,
+    val2twoscomp,
+    val2signmag,
 )
 
 
@@ -332,6 +334,18 @@ class StaticTest(unittest.TestCase):
         }
         res = process_monver(msg)
         self.assertEqual(res, EXPECTED_RESULT)
+
+    def testval2twoscomp(self):
+        res = val2twoscomp(10, "U24")
+        self.assertEqual(res, 0b0000000000000000000001010)
+        res = val2twoscomp(-10, "U24")
+        self.assertEqual(res, 0b111111111111111111110110)
+
+    def testval2signmag(self):
+        res = val2signmag(10, "U24")
+        self.assertEqual(res, 0b0000000000000000000001010)
+        res = val2signmag(-10, "U24")
+        self.assertEqual(res, 0b1000000000000000000001010)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

1. Add helper methods `val2twoscomp` and `val2signmag` to convert signed integer to appropriate two's complement or sign magnitude binary representation. Can be helpful when populating UBX ESF-MEAS `dataField` values such as speed or wheel tick, as these use both varieties of [signed integer representation](https://en.wikipedia.org/wiki/Signed_number_representations).

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] tests added to test_static.py

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
