### PR TITLE
Rc 1.2.49

### DIFF
--- a/.github/workflows/checkpr.yml
+++ b/.github/workflows/checkpr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13.0-rc.3"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13.0-rc.3"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.2.48",
+    "moduleversion": "1.2.49",
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pyubx2 Release Notes
 
+### RELEASE 1.2.49
+
+ENHANCEMENTS:
+
+1. Enhance pyubx2.config_set() exception handling - addresses #173.
+
 ### RELEASE 1.2.48
 
 ENHANCEMENTS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyubx2"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "UBX protocol parser and generator"
-version = "1.2.48"
+version = "1.2.49"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.48"
+__version__ = "1.2.49"

--- a/src/pyubx2/ubxmessage.py
+++ b/src/pyubx2/ubxmessage.py
@@ -17,7 +17,6 @@ import struct
 from pyubx2.exceptions import UBXMessageError, UBXTypeError
 from pyubx2.ubxhelpers import (
     attsiz,
-    atttyp,
     bytes2val,
     calc_checksum,
     cfgkey2name,
@@ -30,7 +29,6 @@ from pyubx2.ubxhelpers import (
     nomval,
     val2bytes,
 )
-from pyubx2.ubxtypes_configdb import CFDBTYPE
 from pyubx2.ubxtypes_core import (
     CH,
     GET,
@@ -740,10 +738,6 @@ class UBXMessage:
             else:
                 kid = key
                 (key, att) = cfgkey2name(key)  # lookup attribute type
-            if type(val) != CFDBTYPE[atttyp(att)]:
-                raise TypeError(
-                    f"Configuration {kid:#08x} ({key}) value {val} must be {CFDBTYPE[atttyp(att)]}, not {type(val)}"
-                )
             keyb = val2bytes(kid, U4)
             valb = val2bytes(val, att)
             lis = lis + keyb + valb

--- a/src/pyubx2/ubxtypes_configdb.py
+++ b/src/pyubx2/ubxtypes_configdb.py
@@ -33,17 +33,6 @@ from pyubx2.ubxtypes_core import (
     L,
 )
 
-CFDBTYPE = {
-    "C": type(b"0"),
-    "E": type(0),
-    "I": type(0),
-    "L": type(0),
-    "R": type(0.1),
-    "U": type(0),
-    "X": type(b"0"),
-}
-"""Configuration Ddtabase permissible attribute types"""
-
 # memory layer designators for CFG_VALSET & CFG_VALDEL
 SET_LAYER_RAM = 1
 """Set RAM (volatile) memory layer in UBX-CFG-VALSET, UBX-CFG-VALDEL"""

--- a/src/pyubx2/ubxtypes_core.py
+++ b/src/pyubx2/ubxtypes_core.py
@@ -96,6 +96,18 @@ X24 = "X024"  # Bitfield 24 bytes
 R4 = "R004"  # Float (IEEE 754) Single Precision 4 bytes
 R8 = "R008"  # Float (IEEE 754) Double Precision 8 bytes
 
+ATTTYPE = {
+    "A": type([0, 1]),
+    "C": (type(b"0"), type("0")),
+    "E": type(0),
+    "I": type(0),
+    "L": type(0),
+    "R": (type(0), type(0.1)),
+    "U": type(0),
+    "X": type(b"0"),
+}
+"""Permissible attribute types"""
+
 # ***********************************************
 # THESE ARE THE UBX PROTOCOL CORE MESSAGE CLASSES
 # ***********************************************

--- a/src/pyubx2/ubxtypes_poll.py
+++ b/src/pyubx2/ubxtypes_poll.py
@@ -2,7 +2,9 @@
 UBX Protocol POLL payload definitions.
 
 THESE ARE THE PAYLOAD DEFINITIONS FOR _POLL_ MESSAGES _TO_ THE RECEIVER
-(e.g. query configuration; request monitoring, receiver management, logging or sensor fusion status).
+(e.g. query configuration; request monitoring, receiver management, 
+logging or sensor fusion status).
+
 Response payloads are defined in UBX_PAYLOADS_GET.
 
 NB: Attribute names must be unique within each message class/id

--- a/tests/test_configdb.py
+++ b/tests/test_configdb.py
@@ -11,7 +11,7 @@ Created on 19 Apr 2021
 
 import unittest
 
-from pyubx2 import UBXMessage, SET, POLL
+from pyubx2 import UBXMessage, SET, POLL, SET_LAYER_FLASH, TXN_NONE
 from pyubx2.ubxtypes_configdb import UBX_CONFIG_DATABASE
 from tests.configdb_baseline import UBX_CONFIG_DATABASE_BASELINE
 
@@ -62,6 +62,16 @@ class ConfigTest(unittest.TestCase):
             payload=b"\x00\x03\x00\x00\x01\x00\x52\x40\x80\x25\x00\x00",
         )
         self.assertEqual(str(res), EXPECTED_RESULT)
+
+    def testGOODConfigSet(self):
+        EXPECTED_RESULT = "<UBX(CFG-VALSET, version=0, ram=0, bbr=0, flash=1, action=0, reserved0=0, CFG_NAVSPG_USRDAT_ROTZ=0.0, CFG_NAVSPG_USRDAT_ROTY=0.10000000149011612)>"
+        msg = UBXMessage.config_set(
+            layers=SET_LAYER_FLASH,
+            transaction=TXN_NONE,
+            cfgData=[(0x40110069, 0), (0x40110068, 0.1)],
+        )
+        # print(msg)
+        self.assertEqual(str(msg), EXPECTED_RESULT)
 
 
 if __name__ == "__main__":

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -420,6 +420,12 @@ class ExceptionTest(unittest.TestCase):
                 transaction=TXN_NONE,
                 cfgData=[(0x5005002A, b"\x00")],
             )
+        with self.assertRaises(TypeError):
+            UBXMessage.config_set(
+                layers=SET_LAYER_FLASH,
+                transaction=TXN_NONE,
+                cfgData=[(0x40110069, 0.1), (0x40110068, "0")],
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -17,6 +17,7 @@ from datetime import datetime
 import pyubx2.ubxtypes_core as ubt
 from pyubx2 import POLL, SET, UBX_CLASSES, UBXMessage, UBXReader
 from pyubx2.ubxhelpers import (
+    attsiz,
     att2idx,
     att2name,
     bytes2val,
@@ -257,6 +258,10 @@ class StaticTest(unittest.TestCase):
         EXPECTED_RESULT = "000: 2447 4e47 4c4c 2c35 3332 372e 3034 3331  | b'$GNGLL,5327.0431' |\n016: 392c 532c 3030 3231 342e 3431 3339 362c  | b'9,S,00214.41396,' |\n032: 452c 3232 3332 3332 2e30 302c 412c 412a  | b'E,223232.00,A,A*' |\n048: 3638 0d0a                                | b'68\\r\\n' |\n"
         res = hextable(b"$GNGLL,5327.04319,S,00214.41396,E,223232.00,A,A*68\r\n", 8)
         self.assertEqual(res, EXPECTED_RESULT)
+
+    def testattsiz(self):  # test attsiz
+        self.assertEqual(attsiz("CH"), -1)
+        self.assertEqual(attsiz("C032"), 32)
 
     def testatt2idx(self):  # test att2idx
         EXPECTED_RESULT = [4, 16, 101, 0, (3, 6), 0]


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

1. Enhance exception handling in `val2bytes()` to explicitly validate value type e.g.
```
...
TypeError: Attribute type X001 value 0 must be <class 'bytes'>, not <class 'int'>
```

Fixes #172 #173

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] tests added to test_exceptions.py

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
