### PR TITLE
Rc 1.2.58

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,16 @@
 {
+    // These test, build and deploy tasks are targeted at a venv
+    // called 'pygpsclient' located in the user's home directory.
+    // Set your workspace default VSCode Python interpreter to
+    // this venv, i.e.
+    // "${userHome}/pygpsclient/bin/python3" on linux/macos
+    // "${userHome}/pygpsclient/Scripts/python" on windows
     "python.testing.pytestEnabled": true,
-    "python.testing.unittestEnabled": false,
     "python.terminal.activateEnvironment": true,
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    //"venv": "${env:UserProfile}/pygpsclient",
-    "venv": "${env:HOME}/pygpsclient",
+    "venv": "${userHome}/pygpsclient",
     "python.testing.pytestArgs": [
         "tests"
     ],
@@ -16,4 +20,7 @@
     "chat.notifyWindowOnConfirmation": false,
     "telemetry.feedback.enabled": false,
     "python.analysis.addHoverSummaries": false,
+    "python-envs.defaultEnvManager": "ms-python.python:venv",
+    "python-envs.pythonProjects": [],
+    "python.defaultInterpreterPath": "${userHome}/pygpsclient/bin/python3"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,18 +1,10 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    //
-    // This VSCode development workflow is intended to work on
-    // MacOS, Linux and Windows (with Powershell>=5.1).
-    //
-    // Use the Install Deploy Dependencies tasks to install the necessary
-    // build and test packages into the system environment.
-    //
-    // Use the Create Venv task to create a virtual environment in the
-    // designated directory. Select this environment using Select
-    // Interpreter to auto-activate it via New Terminal.
-    //
-    // Remember to include any global Python bin (Scripts on Windows) in PATH.
+    // These test, build and deploy tasks are targeted at a venv
+    // called 'pygpsclient' located in the user's home directory.
+    // Set your workspace default VSCode Python interpreter to
+    // this venv, i.e.
+    // "${userHome}/pygpsclient/bin/python3" on linux/macos
+    // "${userHome}/pygpsclient/Scripts/python" on windows
     "version": "2.0.0",
     "tasks": [
         {
@@ -250,15 +242,6 @@
                 "Sphinx HTML"
             ],
             "problemMatcher": []
-        },
-        {
-            "label": "Benchmark",
-            "type": "process",
-            "command": "${config:python.defaultInterpreterPath}",
-            "args": [
-                "${workspaceFolder}/examples/benchmark.py",
-            ],
-            "problemMatcher": []
-        },
+        }
     ]
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License ("BSD License 2.0", "Revised BSD License", "New BSD License", or "Modified BSD License")
 
-Copyright (c) 2020, SEMU Consulting
+Copyright (c) 2020, semuadin (Steve Smith)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ### RELEASE 1.2.58
 
+1. Minimum pynmeagps version updated to 1.0.54 - incorporates additional support for proprietary Quectel NMEA sentences.
 1. Minor updates to `itow2utc()` helper methods to add leapsecond offset parameter (defaults to 18, valid from 2017).
 
 ### RELEASE 1.2.57

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # pyubx2 Release Notes
 
+### RELEASE 1.2.58
+
+1. Minor updates to `itow2utc()` helper methods to add leapsecond offset parameter (defaults to 18, valid from 2017).
+
 ### RELEASE 1.2.57
 
 ENHANCEMENTS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 
-dependencies = ["pynmeagps >= 1.0.53", "pyrtcm >= 1.1.9"]
+dependencies = ["pynmeagps >= 1.0.54", "pyrtcm >= 1.1.9"]
 
 [project.urls]
 homepage = "https://github.com/semuconsulting/pyubx2"

--- a/src/pyubx2/__init__.py
+++ b/src/pyubx2/__init__.py
@@ -8,7 +8,11 @@ Created on 27 Sep 2020
 
 from pynmeagps import (
     SocketWrapper,
+    area,
     bearing,
+    deg2dmm,
+    deg2dms,
+    dms2deg,
     ecef2llh,
     haversine,
     latlon2dmm,

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.2.57"
+__version__ = "1.2.58"

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -170,10 +170,19 @@ class StaticTest(unittest.TestCase):
         res = str(itow2utc(387092000))
         self.assertEqual(res, "11:31:14")
 
+    def testitow2utcLEAP(self):
+        res = str(itow2utc(387092000, 16))
+        self.assertEqual(res, "11:31:16")
+
     def testutc2itow(self):
         dt = datetime(2024, 2, 8, 11, 31, 14)
         res = utc2itow(dt)
         self.assertEqual(res, (2300, 387092000))
+
+    def testutc2itowLEAP(self):
+        dt = datetime(2024, 2, 8, 11, 31, 14)
+        res = utc2itow(dt, 10)
+        self.assertEqual(res, (2300, 387084000))
 
     def testgnss2str(self):
         GNSS = {
@@ -265,7 +274,7 @@ class StaticTest(unittest.TestCase):
         self.assertEqual(res, 0)
 
     def testhextable(self):  # test hextable*( method)
-        EXPECTED_RESULT = "000: 2447 4e47 4c4c 2c35 3332 372e 3034 3331  | b'$GNGLL,5327.0431' |\n016: 392c 532c 3030 3231 342e 3431 3339 362c  | b'9,S,00214.41396,' |\n032: 452c 3232 3332 3332 2e30 302c 412c 412a  | b'E,223232.00,A,A*' |\n048: 3638 0d0a                                | b'68\\r\\n' |\n"
+        EXPECTED_RESULT = "000: 2447 4e47 4c4c 2c35 3332 372e 3034 3331  | b'$GNGLL,5327.0431'                                                 |\n016: 392c 532c 3030 3231 342e 3431 3339 362c  | b'9,S,00214.41396,'                                                 |\n032: 452c 3232 3332 3332 2e30 302c 412c 412a  | b'E,223232.00,A,A*'                                                 |\n048: 3638 0d0a                                | b'68\\r\\n'                                                           |\n"
         res = hextable(b"$GNGLL,5327.04319,S,00214.41396,E,223232.00,A,A*68\r\n", 8)
         self.assertEqual(res, EXPECTED_RESULT)
 


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

1. Minimum pynmeagps version updated to 1.0.54 - incorporates additional support for proprietary Quectel NMEA sentences.
1. Minor updates to `itow2utc()` helper methods to add leapsecond offset parameter (defaults to 18, valid from 2017).

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
