### PR TITLE
RC 1.3.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,7 @@
     "C_Cpp.copilotHover": "disabled",
     "chat.agent.enabled": false,
     "chat.commandCenter.enabled": false,
-    "chat.notifyWindowOnConfirmation": false,
+    "chat.notifyWindowOnConfirmation": "off",
     "telemetry.feedback.enabled": false,
     "python.analysis.addHoverSummaries": false,
     "python-envs.defaultEnvManager": "ms-python.python:venv",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # pyubx2 Release Notes
 
+### RELEASE 1.3.1
+
+1. Fix spurious type validation in 'X' CFG-VALGET attributes - Fixes #204.
+
 ### RELEASE 1.3.0
 
 1. Add support for UBX MGA advanced calibration support commands and polls (MGA-SF-INI, MGA-SF-INI2, MGA-INI-ATT, MGA-SF) - thanks to @ariansharifi for contribution.

--- a/docs/pyubx2.rst
+++ b/docs/pyubx2.rst
@@ -9,93 +9,93 @@ pyubx2.exceptions module
 
 .. automodule:: pyubx2.exceptions
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxhelpers module
 ------------------------
 
 .. automodule:: pyubx2.ubxhelpers
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxmessage module
 ------------------------
 
 .. automodule:: pyubx2.ubxmessage
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxreader module
 -----------------------
 
 .. automodule:: pyubx2.ubxreader
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxtypes\_configdb module
 --------------------------------
 
 .. automodule:: pyubx2.ubxtypes_configdb
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxtypes\_core module
 ----------------------------
 
 .. automodule:: pyubx2.ubxtypes_core
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxtypes\_decodes module
 -------------------------------
 
 .. automodule:: pyubx2.ubxtypes_decodes
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxtypes\_get module
 ---------------------------
 
 .. automodule:: pyubx2.ubxtypes_get
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxtypes\_poll module
 ----------------------------
 
 .. automodule:: pyubx2.ubxtypes_poll
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxtypes\_set module
 ---------------------------
 
 .. automodule:: pyubx2.ubxtypes_set
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 pyubx2.ubxvariants module
 -------------------------
 
 .. automodule:: pyubx2.ubxvariants
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:
 
 Module contents
 ---------------
 
 .. automodule:: pyubx2
    :members:
-   :show-inheritance:
    :undoc-members:
+   :show-inheritance:

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/src/pyubx2/ubxtypes_core.py
+++ b/src/pyubx2/ubxtypes_core.py
@@ -106,7 +106,7 @@ ATTTYPE = {
     "L": type(0),
     "R": (type(0), type(0.1)),
     "U": type(0),
-    "X": type(b"0"),
+    "X": (type(b"0"), type(bytearray(b"0"))),
 }
 """Permissible attribute types"""
 

--- a/tests/test_configdb.py
+++ b/tests/test_configdb.py
@@ -11,7 +11,7 @@ Created on 19 Apr 2021
 
 import unittest
 
-from pyubx2 import UBXMessage, SET, POLL, SET_LAYER_FLASH, TXN_NONE, SET_LAYER_BBR
+from pyubx2 import UBXMessage, SET, POLL, SET_LAYER_FLASH, TXN_NONE, SET_LAYER_BBR, SET_LAYER_RAM
 from pyubx2.ubxtypes_configdb import UBX_CONFIG_DATABASE
 from tests.configdb_baseline import UBX_CONFIG_DATABASE_BASELINE
 
@@ -93,6 +93,23 @@ class ConfigTest(unittest.TestCase):
         msg = UBXMessage.config_del(layers, transaction, cfgdata)
         # print(msg)
         self.assertEqual(str(msg), EXPECTED_RESULT3)
+
+    def testbytearray(self):
+        EXPECTED_RESULT1 = "<UBX(CFG-VALSET, version=0, ram=1, bbr=0, flash=0, action=0, reserved0=0, CFG_SBAS_PRNSCANMASK=b'\\x88\\xab\\x03\\x00')>"
+        layers = SET_LAYER_RAM  # volatile RAM
+        transaction = TXN_NONE
+        cfgdata = [
+            ("CFG_SBAS_PRNSCANMASK", b"\x88\xab\x03\x00"),
+        ]
+        msg = UBXMessage.config_set(layers, transaction, cfgdata)
+        #print(msg)
+        self.assertEqual(str(msg), EXPECTED_RESULT1)
+        cfgdata = [
+            ("CFG_SBAS_PRNSCANMASK", bytearray((0x88,0xab,0x03,0x00))),
+        ]
+        msg = UBXMessage.config_set(layers, transaction, cfgdata)
+        #print(msg)
+        self.assertEqual(str(msg), EXPECTED_RESULT1)
 
 
 if __name__ == "__main__":

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -403,11 +403,9 @@ class FillTest(unittest.TestCase):
                 POLL,
             )
         )
-        with open("pygpsdata-mgasf.log", "wb") as output:
-            for i, msg in enumerate(res):
-                # print(f'"{msg}",')
-                self.assertEqual(str(res[i]), EXPECTED_RESULT[i])
-                output.write(msg.serialize())
+        for i, msg in enumerate(res):
+            # print(f'"{msg}",')
+            self.assertEqual(str(res[i]), EXPECTED_RESULT[i])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description


1. Fix spurious type validation in 'X' CFG-VALGET attributes - Fixes #204.

Fixes #204

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] test_configdb.py updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
