### PR TITLE
RC 1.3.6

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,45 @@
 # pyubx2 Release Notes
 
+### RELEASE 1.3.6
+
+1. Add `msgfilter` argument to UBXReader to allow user to filter output by one or more message identities. If set, only filtered raw messages will be parsed (e.g. UBX `0x0107` *(must be integer)*, NMEA `"GNGSA"` or RTCM `1077`); the remainder will be `None`. Default is "" (no filter). If you're only interested in specific messages, this can significantly improve parsing speed for a given datastream.
+
+    ```
+    from pyubx2 import UBXReader
+
+    with open("ubxdata.log",'rb') as stream:
+       ubr = UBXReader(stream, msgfilter=(0x0107,0x0104)) # NAV-PVT, NAV-DOP
+       for raw, parsed in ubr:
+          if parsed is not None:
+             print(parsed)
+    ```
+    ```
+    <UBX(NAV-DOP, iTOW=16:31:54, gDOP=1.17, pDOP=1.04, tDOP=0.54, vDOP=0.89, hDOP=0.53, nDOP=0.39, eDOP=0.36)>
+    <UBX(NAV-PVT, iTOW=16:31:55, year=2024, month=8, day=23, hour=16, min
+    ...
+    ```
+1. Enhance `parsing` argument to UBXReader - permissible values:
+   - `PARSE_NONE` (0) - No message parsing, raw output only. Parsed data is `None`.
+   - `PARSE_FULL` (1) - Full parsing of all message attributes (the default). Parsed data is a `UBXMessage`, `NMEAMessage` or `RTCMMessage` object.
+   - `PARSE_META` (2) - Parse only basic metadata from messages (protocol, identity and length). Parsed data is a formatted `str` object. Significantly faster than full parsing, but individual data attributes will no longer be available.
+
+    ```
+    from pyubx2 import UBXReader, PARSE_META
+
+    with open("ubxdata.log",'rb') as stream:
+       ubr = UBXReader(stream, parsing=PARSE_META)
+       for raw, parsed in ubr:
+          if parsed is not None:
+             print(parsed)
+    ```
+    ```
+    <UBX(0x0107, length=100, data=b'\xb5b\x01\x07\\\x00(\ ... )>
+    <RTCM(1042, length=70, data=b'\xd3\x00@A(\x87\x98\x1e ... )>
+    ...
+    ```
+
+**FYI** See also [pygnssutils.GNSSReader](https://github.com/semuconsulting/pygnssutils#gnssreader), which offers similar functionality to UBXReader but for a wider range of GNSS protocols, and outputs a generic `GNSSMessage` object (*rather than a `str` object*) when `parsing=PARSE_META`.
+
 ### RELEASE 1.3.5
 
 1. Update NAV-DAHEADING v2 message definition for production firmware HDG 2.00 Interface Specification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 
-dependencies = ["pynmeagps >= 1.1.5", "pyrtcm >= 1.1.12"]
+dependencies = ["pynmeagps >= 1.1.5", "pyrtcm >= 1.2.0"]
 
 [project.urls]
 homepage = "https://github.com/semuconsulting/pyubx2"

--- a/src/pyubx2/_version.py
+++ b/src/pyubx2/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"

--- a/src/pyubx2/ubxreader.py
+++ b/src/pyubx2/ubxreader.py
@@ -8,6 +8,8 @@ Returns both the raw binary data (as bytes) and the parsed data
 (as a UBXMessage, NMEAMessage or RTCMMessage object).
 
 - 'protfilter' governs which protocols (NMEA, UBX or RTCM3) are processed
+- 'msgfilter' governs which individual message types are processed.
+- `parsing` governs whether payloads are fully or partially parsed.
 - 'quitonerror' governs how errors are handled
 - 'msgmode' indicates the type of UBX datastream (output GET, input SET, query POLL).
   If msgmode is set to SETPOLL, input/query mode will be automatically detected by parser.
@@ -42,13 +44,21 @@ from pyubx2.exceptions import (
     UBXStreamError,
     UBXTypeError,
 )
-from pyubx2.ubxhelpers import bytes2val, calc_checksum, getinputmode, val2bytes
+from pyubx2.ubxhelpers import (
+    bytes2val,
+    calc_checksum,
+    escapeall,
+    getinputmode,
+    val2bytes,
+)
 from pyubx2.ubxmessage import UBXMessage
 from pyubx2.ubxtypes_core import (
     ERR_LOG,
     ERR_RAISE,
     GET,
     NMEA_PROTOCOL,
+    PARSE_FULL,
+    PARSE_META,
     POLL,
     RTCM3_PROTOCOL,
     SET,
@@ -75,9 +85,10 @@ class UBXReader:
         parsebitfield: Literal[0, 1, 2] = 1,
         labelmsm: Literal[1, 2] = 1,
         bufsize: int = DEFAULT_BUFSIZE,
-        parsing: bool = True,
+        parsing: Literal[0, 1, 2] = PARSE_FULL,
         errorhandler: FunctionType | NoneType = None,
         encoding: int = ENCODE_NONE,
+        msgfilter: tuple | int | str = "",
     ):
         """Constructor.
 
@@ -93,10 +104,13 @@ class UBXReader:
             individual bits, 2 = parse as bytes and bits (1)
         :param Literal[1,2] labelmsm: RTCM3 MSM label type 1 = RINEX, 2 = BAND (1)
         :param int bufsize: socket recv buffer size (4096)
-        :param bool parsing: True = parse data, False = don't parse data (output raw only) (True)
+        :param Literal[0,1,2] parsing: PARSE_NONE (0) = no parsing (raw only), \
+            PARSE_FULL (1) = full parsing, PARSE_META (2) = parse metadata only (1)
         :param FunctionType | NoneType errorhandler: error handling object or function (None)
         :param int encoding: encoding for socket stream \
             (0 = none, 1 = chunk, 2 = gzip, 4 = compress, 8 = deflate (can be OR'd)) (0)
+        :param tuple | int | str msgfilter: parsed message filter ("" = ALL) \
+            UBX identity must be entered as integer e.g. 0x0107
         :raises: UBXStreamError (if mode is invalid)
         """
         # pylint: disable=too-many-arguments
@@ -106,6 +120,10 @@ class UBXReader:
         else:
             self._stream = datastream
         self._protfilter = protfilter
+        self._msgfilter = (
+            (msgfilter,) if not isinstance(msgfilter, tuple) else msgfilter
+        )
+        self._filtermsg = self._msgfilter not in ((), ("",))
         self._quitonerror = quitonerror
         self._errorhandler = errorhandler
         self._validate = validate
@@ -227,19 +245,22 @@ class UBXReader:
 
         return (raw_data, parsed_data)
 
-    def _parse_ubx(self, hdr: bytes) -> tuple[bytes | NoneType, UBXMessage | NoneType]:
+    def _parse_ubx(
+        self, hdr: bytes
+    ) -> tuple[bytes | NoneType, UBXMessage | str | NoneType]:
         """
         Parse remainder of UBX message.
 
         :param bytes hdr: UBX header (b'\\xb5\\x62')
         :return: tuple of (raw_data as bytes, parsed_data as UBXMessage or None)
-        :rtype: tuple[bytes | NoneType, UBXMessage | NoneType]
+        :rtype: tuple[bytes | NoneType, UBXMessage | str | NoneType]
         """
 
         # read the rest of the UBX message from the buffer
         byten = self._read_bytes(4)
         clsid = byten[0:1]
         msgid = byten[1:2]
+        msgidi = int.from_bytes(clsid + msgid, "big")
         lenb = byten[2:4]
         leni = int.from_bytes(lenb, "little", signed=False)
         byten = self._read_bytes(leni + 2)
@@ -247,69 +268,81 @@ class UBXReader:
         cksum = byten[leni : leni + 2]
         raw_data = hdr + clsid + msgid + lenb + plb + cksum
         # only parse if we need to (filter passes UBX)
-        if (self._protfilter & UBX_PROTOCOL) and self._parsing:
-            parsed_data = self.parse(
-                raw_data,
-                validate=self._validate,
-                msgmode=self._msgmode,
-                parsebitfield=self._parsebf,
-            )
-        else:
-            parsed_data = None
+        parsed_data = None
+        if self._protfilter & UBX_PROTOCOL and (
+            not self._filtermsg or msgidi in self._msgfilter
+        ):
+            if self._parsing == PARSE_FULL:
+                parsed_data = UBXReader.parse(
+                    raw_data,
+                    validate=self._validate,
+                    msgmode=self._msgmode,
+                    parsebitfield=self._parsebf,
+                )
+            elif self._parsing == PARSE_META:
+                parsed_data = f"<UBX(0x{msgidi:04x}, length={len(raw_data)}, data={escapeall(raw_data)}"
         return (raw_data, parsed_data)
 
     def _parse_nmea(
         self, hdr: bytes
-    ) -> tuple[bytes | NoneType, NMEAMessage | NoneType]:
+    ) -> tuple[bytes | NoneType, NMEAMessage | str | NoneType]:
         """
         Parse remainder of NMEA message (using pynmeagps library).
 
         :param bytes hdr: NMEA header (b'\\x24\\x..')
         :return: tuple of (raw_data as bytes, parsed_data as NMEAMessage or None)
-        :rtype: tuple[bytes | NoneType, NMEAMessage | NoneType]
+        :rtype: tuple[bytes | NoneType, NMEAMessage | str | NoneType]
         """
 
         # read the rest of the NMEA message from the buffer
         byten = self._read_line()  # NMEA protocol is CRLF-terminated
         raw_data = hdr + byten
+        msgids = raw_data[1:].decode().split(",", 1)[0]
         # only parse if we need to (filter passes NMEA)
-        if (self._protfilter & NMEA_PROTOCOL) and self._parsing:
-            # invoke pynmeagps parser
-            parsed_data = NMEAReader.parse(
-                raw_data,
-                validate=self._validate,
-                msgmode=self._msgmode,
-            )
-        else:
-            parsed_data = None
+        parsed_data = None
+        if self._protfilter & NMEA_PROTOCOL and (
+            not self._filtermsg or msgids in self._msgfilter
+        ):
+            if self._parsing == PARSE_FULL:
+                parsed_data = NMEAReader.parse(
+                    raw_data,
+                    validate=self._validate,
+                    msgmode=self._msgmode,
+                )
+            elif self._parsing == PARSE_META:
+                parsed_data = f"<NMEA({msgids}, length={len(raw_data)}, data={raw_data}"
         return (raw_data, parsed_data)
 
     def _parse_rtcm3(
         self, hdr: bytes
-    ) -> tuple[bytes | NoneType, RTCMMessage | NoneType]:
+    ) -> tuple[bytes | NoneType, RTCMMessage | str | NoneType]:
         """
         Parse any RTCM3 data in the stream (using pyrtcm library).
 
         :param bytes hdr: first 2 bytes of RTCM3 header
         :return: tuple of (raw_data as bytes, parsed_stub as RTCMMessage)
-        :rtype: tuple[bytes | NoneType, RTCMMessage | NoneType]
+        :rtype: tuple[bytes | NoneType, RTCMMessage | str | NoneType]
         """
 
         hdr3 = self._read_bytes(1)
         size = hdr3[0] | (hdr[1] << 8)
         payload = self._read_bytes(size)
+        msgidi = ((int.from_bytes(payload[0:2], "big")) >> 4) & 0xFFF
         crc = self._read_bytes(3)
         raw_data = hdr + hdr3 + payload + crc
         # only parse if we need to (filter passes RTCM)
-        if (self._protfilter & RTCM3_PROTOCOL) and self._parsing:
-            # invoke pyrtcm parser
-            parsed_data = RTCMReader.parse(
-                raw_data,
-                validate=self._validate,
-                labelmsm=self._labelmsm,
-            )
-        else:
-            parsed_data = None
+        parsed_data = None
+        if self._protfilter & RTCM3_PROTOCOL and (
+            not self._filtermsg or msgidi in self._msgfilter
+        ):
+            if self._parsing == PARSE_FULL:
+                parsed_data = RTCMReader.parse(
+                    raw_data,
+                    validate=self._validate,
+                    labelmsm=self._labelmsm,
+                )
+            elif self._parsing == PARSE_META:
+                parsed_data = f"<RTCM({msgidi}, length={len(raw_data)}, data={raw_data}"
         return (raw_data, parsed_data)
 
     def _read_bytes(self, size: int) -> bytes:

--- a/src/pyubx2/ubxtypes_core.py
+++ b/src/pyubx2/ubxtypes_core.py
@@ -28,6 +28,12 @@ UBX_PROTOCOL = 2
 """UBX Protocol"""
 RTCM3_PROTOCOL = 4
 """RTCM3 Protocol"""
+PARSE_NONE = 0
+"""No Parsing, raw output only"""
+PARSE_FULL = 1
+"""Full parsing of all attributes"""
+PARSE_META = 2
+"""Parse metadata only"""
 ERR_RAISE = 2
 """Raise error and quit"""
 ERR_LOG = 1

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -144,6 +144,25 @@ class StreamTest(unittest.TestCase):
                 i += 1
             self.assertEqual(i, len(EXPECTED_RESULTS))
 
+    def testNAVLOG2_filteredmeta(
+        self,
+    ):  # test stream of UBX NAV messages with parsebitfield = 2
+        EXPECTED_RESULTS = (
+            "<UBX(0x0107, length=100, ",
+            "<UBX(0x0135, length=532, ",
+            "<UBX(0x0104, length=26, ",
+        )
+        i = 0
+        with open(os.path.join(DIRNAME, "pygpsdata-NAV.log"), "rb") as stream:
+            ubr = UBXReader(stream, parsebitfield=2,parsing=2,msgfilter=(0x0107,0x0135,0x0104))
+            for raw, parsed in ubr:
+                if parsed is not None:
+                    d = parsed.split("data=",1)[0]
+                    #print(f'"{d}",')
+                    self.assertEqual(d, EXPECTED_RESULTS[i])
+                    i += 1
+            self.assertEqual(i, len(EXPECTED_RESULTS))
+
     def testHNRLOG(
         self,
     ):  # test stream of UBX HNR messages
@@ -459,6 +478,25 @@ class StreamTest(unittest.TestCase):
                 i += 1
             self.assertEqual(i, 10)
             # sys.stdout = stdout_saved
+
+    def testMIXEDRTCM_filteredmeta(
+        self,
+    ):  # test stream of UBX NAV messages with parsebitfield = 2
+        EXPECTED_RESULTS = (
+            "<RTCM(1077, length=275, ",
+            "<UBX(0x0107, length=100, ",
+            "<NMEA(GNRMC, length=70, ",
+        )
+        i = 0
+        with open(os.path.join(DIRNAME, "pygpsdata-MIXED-RTCM3.log"), "rb") as stream:
+            ubr = UBXReader(stream, protfilter=7,parsing=2,msgfilter=(1077,"GNRMC",0x0107))
+            for raw, parsed in ubr:
+                if parsed is not None:
+                    d = parsed.split("data=",1)[0]
+                    # print(f'"{d}",')
+                    self.assertEqual(d, EXPECTED_RESULTS[i])
+                    i += 1
+            self.assertEqual(i, len(EXPECTED_RESULTS))
 
     def testMIXEDRTCM2(
         self,


### PR DESCRIPTION
# pyubx2 Pull Request Template

## Description

1. Add `msgfilter` argument to UBXReader to allow user to filter output by one or more message identities. If set, only filtered raw messages will be parsed (e.g. UBX `0x0107` *(must be integer)*, NMEA `"GNGSA"` or RTCM `1077`); the remainder will be `None`. Default is "" (no filter). If you're only interested in specific messages, this can significantly improve parsing speed for a given datastream.

    ```
    from pyubx2 import UBXReader

    with open("ubxdata.log",'rb') as stream:
       ubr = UBXReader(stream, msgfilter=(0x0107,0x0104)) # NAV-PVT, NAV-DOP
       for raw, parsed in ubr:
          if parsed is not None:
             print(parsed)
    ```
    ```
    <UBX(NAV-DOP, iTOW=16:31:54, gDOP=1.17, pDOP=1.04, tDOP=0.54, vDOP=0.89, hDOP=0.53, nDOP=0.39, eDOP=0.36)>
    <UBX(NAV-PVT, iTOW=16:31:55, year=2024, month=8, day=23, hour=16, min
    ...
    ```
1. Enhance `parsing` argument to UBXReader - permissible values:
   - `PARSE_NONE` (0) - No message parsing, raw output only. Parsed data is `None`.
   - `PARSE_FULL` (1) - Full parsing of all message attributes (the default). Parsed data is a `UBXMessage`, `NMEAMessage` or `RTCMMessage` object.
   - `PARSE_META` (2) - Parse only basic metadata from messages (protocol, identity and length). Parsed data is a formatted `str` object. Significantly faster than full parsing, but individual data attributes will no longer be available.

    ```
    from pyubx2 import UBXReader, PARSE_META

    with open("ubxdata.log",'rb') as stream:
       ubr = UBXReader(stream, parsing=PARSE_META)
       for raw, parsed in ubr:
          if parsed is not None:
             print(parsed)
    ```
    ```
    <UBX(0x0107, length=100, data=b'\xb5b\x01\x07\\\x00(\ ... )>
    <RTCM(1042, length=70, data=b'\xd3\x00@A(\x87\x98\x1e ... )>
    ...
    ```

**FYI** See also [pygnssutils.GNSSReader](https://github.com/semuconsulting/pygnssutils#gnssreader), which offers similar functionality to UBXReader but for a wider range of GNSS protocols, and outputs a generic `GNSSMessage` object (*rather than a `str` object*) when `parsing=PARSE_META`.
Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new UBX message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`ubxtypes_configdb.py`).

- [x] test_stream.py updated
- [ ] Test B

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
